### PR TITLE
Add JSON Schema and Python validator

### DIFF
--- a/core-spec/osi-schema.json
+++ b/core-spec/osi-schema.json
@@ -1,0 +1,339 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/osi-initiative/osi/core-spec/osi-schema.json",
+  "title": "OSI Core Metadata Specification",
+  "description": "JSON Schema for validating OSI (Open Semantic Interoperability) semantic model definitions",
+  "type": "object",
+  "properties": {
+    "dialects": {
+      "type": "array",
+      "description": "Supported expression language dialects (enumeration definition)",
+      "items": {
+        "$ref": "#/$defs/Dialect"
+      }
+    },
+    "vendors": {
+      "type": "array",
+      "description": "Supported vendors for custom extensions (enumeration definition)",
+      "items": {
+        "$ref": "#/$defs/Vendor"
+      }
+    },
+    "semantic_model": {
+      "type": "array",
+      "description": "Collection of semantic model definitions",
+      "items": {
+        "$ref": "#/$defs/SemanticModel"
+      }
+    }
+  },
+  "required": ["semantic_model"],
+  "additionalProperties": false,
+  "$defs": {
+    "Dialect": {
+      "type": "string",
+      "enum": ["ANSI_SQL", "SNOWFLAKE", "MDX", "TABLEAU", "DATABRICKS"],
+      "description": "Supported SQL and expression language dialects"
+    },
+    "Vendor": {
+      "type": "string",
+      "enum": ["COMMON", "SNOWFLAKE", "SALESFORCE", "DBT", "DATABRICKS"],
+      "description": "Supported vendors for custom extensions"
+    },
+    "AIContext": {
+      "description": "Additional context for AI tools",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "instructions": {
+              "type": "string",
+              "description": "Instructions for AI on how to use this entity"
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Alternative names and terms"
+            },
+            "examples": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sample questions or use cases"
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "CustomExtension": {
+      "type": "object",
+      "description": "Vendor-specific attributes for extensibility",
+      "properties": {
+        "vendor_name": {
+          "$ref": "#/$defs/Vendor"
+        },
+        "data": {
+          "type": "string",
+          "description": "JSON string containing vendor-specific data"
+        }
+      },
+      "required": ["vendor_name", "data"],
+      "additionalProperties": false
+    },
+    "DialectExpression": {
+      "type": "object",
+      "description": "Expression in a specific dialect",
+      "properties": {
+        "dialect": {
+          "$ref": "#/$defs/Dialect"
+        },
+        "expression": {
+          "type": "string",
+          "description": "SQL or dialect-specific expression"
+        }
+      },
+      "required": ["dialect", "expression"],
+      "additionalProperties": false
+    },
+    "Expression": {
+      "type": "object",
+      "description": "Expression definition with multi-dialect support",
+      "properties": {
+        "dialects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DialectExpression"
+          },
+          "minItems": 1
+        }
+      },
+      "required": ["dialects"],
+      "additionalProperties": false
+    },
+    "Dimension": {
+      "type": "object",
+      "description": "Dimension metadata",
+      "properties": {
+        "is_time": {
+          "type": "boolean",
+          "description": "Indicates if this is a time-based dimension for temporal filtering"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Field": {
+      "type": "object",
+      "description": "Row-level attribute for grouping, filtering, and metric expressions",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the field within the dataset"
+        },
+        "expression": {
+          "$ref": "#/$defs/Expression"
+        },
+        "dimension": {
+          "$ref": "#/$defs/Dimension"
+        },
+        "label": {
+          "type": "string",
+          "description": "Label for categorization"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "expression"],
+      "additionalProperties": false
+    },
+    "Dataset": {
+      "type": "object",
+      "description": "Logical dataset representing a business entity (fact or dimension table)",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the dataset"
+        },
+        "source": {
+          "type": "string",
+          "description": "Reference to underlying physical table/view (database.schema.table) or query"
+        },
+        "primary_key": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Primary key columns (single or composite)"
+        },
+        "unique_keys": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": "Array of unique key definitions (each can be single or composite)"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Field"
+          }
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "source"],
+      "additionalProperties": false
+    },
+    "Relationship": {
+      "type": "object",
+      "description": "Foreign key relationship between datasets",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the relationship"
+        },
+        "from": {
+          "type": "string",
+          "description": "Dataset on the many side of the relationship"
+        },
+        "to": {
+          "type": "string",
+          "description": "Dataset on the one side of the relationship"
+        },
+        "from_columns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "description": "Foreign key columns in the 'from' dataset"
+        },
+        "to_columns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "description": "Primary/unique key columns in the 'to' dataset"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "from", "to", "from_columns", "to_columns"],
+      "additionalProperties": false
+    },
+    "Metric": {
+      "type": "object",
+      "description": "Quantitative measure defined on business data",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the metric"
+        },
+        "expression": {
+          "$ref": "#/$defs/Expression"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what the metric measures"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "expression"],
+      "additionalProperties": false
+    },
+    "SemanticModel": {
+      "type": "object",
+      "description": "Top-level container representing a complete semantic model",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the semantic model"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "datasets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Dataset"
+          },
+          "minItems": 1,
+          "description": "Collection of logical datasets"
+        },
+        "relationships": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Relationship"
+          },
+          "description": "Defines how datasets are connected"
+        },
+        "metrics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Metric"
+          },
+          "description": "Quantifiable measures spanning datasets"
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "datasets"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/core-spec/osi-schema.json
+++ b/core-spec/osi-schema.json
@@ -1,10 +1,15 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/osi-initiative/osi/core-spec/osi-schema.json",
+  "$id": "https://github.com/open-semantic-interchange/OSI/core-spec/osi-schema.json",
   "title": "OSI Core Metadata Specification",
   "description": "JSON Schema for validating OSI (Open Semantic Interoperability) semantic model definitions",
   "type": "object",
   "properties": {
+    "version": {
+      "type": "string",
+      "const": "1.0",
+      "description": "OSI specification version"
+    },
     "dialects": {
       "type": "array",
       "description": "Supported expression language dialects (enumeration definition)",
@@ -27,7 +32,7 @@
       }
     }
   },
-  "required": ["semantic_model"],
+  "required": ["version", "semantic_model"],
   "additionalProperties": false,
   "$defs": {
     "Dialect": {

--- a/validation/validate.py
+++ b/validation/validate.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""
+OSI Semantic Model Validator
+
+Validates OSI YAML files against:
+1. JSON Schema (structure, types, enums)
+2. Unique names (datasets, fields, metrics, relationships)
+3. Valid relationship references
+4. SQL syntax (using sqlglot)
+
+Usage:
+    python validation/validate.py <yaml_file>
+    python validation/validate.py examples/tpcds_semantic_model.yaml
+"""
+
+import json
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+    from jsonschema import Draft202012Validator
+except ImportError:
+    print("Missing dependencies. Install with:")
+    print("  pip install pyyaml jsonschema")
+    sys.exit(1)
+
+try:
+    import sqlglot
+    from sqlglot.errors import ParseError
+    SQLGLOT_AVAILABLE = True
+except ImportError:
+    SQLGLOT_AVAILABLE = False
+
+# Map OSI dialects to sqlglot dialects
+DIALECT_MAP = {
+    "ANSI_SQL": None,  # sqlglot default
+    "SNOWFLAKE": "snowflake",
+    "DATABRICKS": "databricks",
+    "MDX": None,  # Not supported by sqlglot, skip validation
+    "TABLEAU": None,  # Not supported by sqlglot, skip validation
+}
+
+# Dialects that sqlglot cannot parse
+SKIP_SQL_VALIDATION = {"MDX", "TABLEAU"}
+
+
+def validate_schema(data: dict, schema: dict) -> list[str]:
+    """Validate against JSON Schema."""
+    validator = Draft202012Validator(schema)
+    errors = []
+    for error in validator.iter_errors(data):
+        path = " -> ".join(str(p) for p in error.absolute_path) if error.absolute_path else "(root)"
+        errors.append(f"[Schema] {path}: {error.message}")
+    return errors
+
+
+def find_duplicates(items: list[str]) -> list[str]:
+    """Find duplicate items in a list."""
+    seen = set()
+    duplicates = []
+    for item in items:
+        if item in seen:
+            duplicates.append(item)
+        seen.add(item)
+    return duplicates
+
+
+def validate_unique_names(data: dict) -> list[str]:
+    """Validate unique names for datasets, fields, metrics, relationships."""
+    errors = []
+
+    for model in data.get("semantic_model", []):
+        model_name = model.get("name", "<unnamed>")
+
+        # Check unique dataset names
+        dataset_names = [d.get("name") for d in model.get("datasets", []) if d.get("name")]
+        for dup in find_duplicates(dataset_names):
+            errors.append(f"[Unique] Duplicate dataset name '{dup}' in model '{model_name}'")
+
+        # Check unique field names within each dataset
+        for dataset in model.get("datasets", []):
+            dataset_name = dataset.get("name", "<unnamed>")
+            field_names = [f.get("name") for f in dataset.get("fields", []) if f.get("name")]
+            for dup in find_duplicates(field_names):
+                errors.append(f"[Unique] Duplicate field name '{dup}' in dataset '{dataset_name}'")
+
+        # Check unique metric names
+        metric_names = [m.get("name") for m in model.get("metrics", []) if m.get("name")]
+        for dup in find_duplicates(metric_names):
+            errors.append(f"[Unique] Duplicate metric name '{dup}' in model '{model_name}'")
+
+        # Check unique relationship names
+        rel_names = [r.get("name") for r in model.get("relationships", []) if r.get("name")]
+        for dup in find_duplicates(rel_names):
+            errors.append(f"[Unique] Duplicate relationship name '{dup}' in model '{model_name}'")
+
+    return errors
+
+
+def validate_references(data: dict) -> list[str]:
+    """Validate that relationships reference existing datasets."""
+    errors = []
+
+    for model in data.get("semantic_model", []):
+        model_name = model.get("name", "<unnamed>")
+        dataset_names = {d.get("name") for d in model.get("datasets", []) if d.get("name")}
+
+        for rel in model.get("relationships", []):
+            rel_name = rel.get("name", "<unnamed>")
+            from_ds = rel.get("from")
+            to_ds = rel.get("to")
+
+            if from_ds and from_ds not in dataset_names:
+                errors.append(f"[Reference] Relationship '{rel_name}' references unknown dataset '{from_ds}'")
+            if to_ds and to_ds not in dataset_names:
+                errors.append(f"[Reference] Relationship '{rel_name}' references unknown dataset '{to_ds}'")
+
+    return errors
+
+
+def validate_sql_expression(expr: str, dialect: str, context: str) -> str | None:
+    """Validate a single SQL expression. Returns error message or None if valid."""
+    if not SQLGLOT_AVAILABLE:
+        return None
+
+    if dialect in SKIP_SQL_VALIDATION:
+        return None
+
+    sqlglot_dialect = DIALECT_MAP.get(dialect)
+
+    try:
+        # Try parsing as expression first (for field expressions like "column_name")
+        sqlglot.parse_one(expr, dialect=sqlglot_dialect)
+        return None
+    except ParseError:
+        pass
+
+    try:
+        # Try wrapping in SELECT for simple column references
+        sqlglot.parse_one(f"SELECT {expr}", dialect=sqlglot_dialect)
+        return None
+    except ParseError as e:
+        return f"[SQL] {context}: {str(e).split(chr(10))[0]}"
+
+
+def validate_sql(data: dict) -> list[str]:
+    """Validate SQL expressions in fields and metrics."""
+    if not SQLGLOT_AVAILABLE:
+        return ["[SQL] Warning: sqlglot not installed, skipping SQL validation. Install with: pip install sqlglot"]
+
+    errors = []
+
+    for model in data.get("semantic_model", []):
+        model_name = model.get("name", "<unnamed>")
+
+        # Validate field expressions
+        for dataset in model.get("datasets", []):
+            dataset_name = dataset.get("name", "<unnamed>")
+            for field in dataset.get("fields", []):
+                field_name = field.get("name", "<unnamed>")
+                expression = field.get("expression", {})
+                for dialect_expr in expression.get("dialects", []):
+                    dialect = dialect_expr.get("dialect", "ANSI_SQL")
+                    expr = dialect_expr.get("expression", "")
+                    if expr:
+                        context = f"Field '{dataset_name}.{field_name}' ({dialect})"
+                        error = validate_sql_expression(expr, dialect, context)
+                        if error:
+                            errors.append(error)
+
+        # Validate metric expressions
+        for metric in model.get("metrics", []):
+            metric_name = metric.get("name", "<unnamed>")
+            expression = metric.get("expression", {})
+            for dialect_expr in expression.get("dialects", []):
+                dialect = dialect_expr.get("dialect", "ANSI_SQL")
+                expr = dialect_expr.get("expression", "")
+                if expr:
+                    context = f"Metric '{metric_name}' ({dialect})"
+                    error = validate_sql_expression(expr, dialect, context)
+                    if error:
+                        errors.append(error)
+
+    return errors
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    yaml_path = Path(sys.argv[1])
+    schema_path = Path(__file__).parent.parent / "core-spec" / "osi-schema.json"
+
+    if not yaml_path.exists():
+        print(f"Error: File not found: {yaml_path}")
+        sys.exit(1)
+
+    if not schema_path.exists():
+        print(f"Error: Schema not found: {schema_path}")
+        sys.exit(1)
+
+    # Load files
+    with open(schema_path) as f:
+        schema = json.load(f)
+
+    with open(yaml_path) as f:
+        try:
+            data = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            print(f"Error: Invalid YAML: {e}")
+            sys.exit(1)
+
+    # Run validations
+    errors = []
+    errors.extend(validate_schema(data, schema))
+    errors.extend(validate_unique_names(data))
+    errors.extend(validate_references(data))
+    errors.extend(validate_sql(data))
+
+    # Report results
+    if errors:
+        # Separate warnings from errors
+        warnings = [e for e in errors if "Warning:" in e]
+        actual_errors = [e for e in errors if "Warning:" not in e]
+
+        for warning in warnings:
+            print(f"  {warning}")
+
+        if actual_errors:
+            print(f"\nValidation FAILED with {len(actual_errors)} error(s):\n")
+            for error in actual_errors:
+                print(f"  {error}")
+            sys.exit(1)
+        else:
+            print(f"Validation PASSED: {yaml_path.name}")
+            sys.exit(0)
+    else:
+        print(f"Validation PASSED: {yaml_path.name}")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `core-spec/osi-schema.json` - JSON Schema (draft 2020-12) for validating OSI semantic model YAML files
- Add `validation/validate.py` - Python validator with extended checks beyond JSON Schema

## JSON Schema Features
- Validates structure, types, and enum values (Dialect, Vendor)
- Uses `additionalProperties: false` for strict validation
- References enum definitions for top-level `dialects`/`vendors` arrays

## Python Validator Features
Checks that JSON Schema cannot enforce:
- Unique dataset names per model
- Unique field names per dataset
- Unique metric/relationship names per model
- Valid relationship references (from/to datasets must exist)
- SQL syntax validation via sqlglot (ANSI_SQL, SNOWFLAKE, DATABRICKS)

## Usage
```bash
pip install pyyaml jsonschema sqlglot
python validation/validate.py examples/tpcds_semantic_model.yaml
```

For VS Code validation, add to YAML files:
```yaml
# yaml-language-server: $schema=../core-spec/osi-schema.json
```

## Test plan
- [x] JSON Schema validates against draft 2020-12 spec
- [x] Example file (tpcds_semantic_model.yaml) passes validation
- [x] Invalid inputs correctly rejected (tested duplicate names, invalid SQL, bad references)