### PR TITLE
Update TPC-DS example to conform to JSON Schema

### DIFF
--- a/examples/tpcds_semantic_model.yaml
+++ b/examples/tpcds_semantic_model.yaml
@@ -1,6 +1,10 @@
+# yaml-language-server: $schema=../core-spec/osi-schema.json
+
 # TPC-DS Semantic Model Example
 # This example demonstrates the OSI Core Metadata Spec using the TPC-DS benchmark schema
 # TPC-DS is a decision support benchmark with a realistic retail business model
+
+version: "1.0"
 
 semantic_model:
   - name: tpcds_retail_model
@@ -555,19 +559,20 @@ semantic_model:
 
     custom_extensions:
       - vendor_name: SALESFORCE
-        data: '{
-          "tableau_workbook_id": "tpcds_retail_dashboard",
-          "einstein_enabled": true,
-          "crm_sync": {
-            "enabled": true,
-            "sync_frequency": "daily",
-            "customer_mapping": "customer.c_customer_id -> Account.AccountNumber"
-          },
-          "tableau_semantics": {
-            "published": true,
-            "version": "1.0"
+        data: |
+          {
+            "tableau_workbook_id": "tpcds_retail_dashboard",
+            "einstein_enabled": true,
+            "crm_sync": {
+              "enabled": true,
+              "sync_frequency": "daily",
+              "customer_mapping": "customer.c_customer_id -> Account.AccountNumber"
+            },
+            "tableau_semantics": {
+              "published": true,
+              "version": "1.0"
+            }
           }
-        }'
 
       - vendor_name: DBT
         data: '{"project_name": "tpcds_analytics", "models_path": "models/semantic"}'


### PR DESCRIPTION
## Summary
- Add YAML language server schema reference for IDE validation support
- Add required `version: "1.0"` property to conform to the JSON Schema
- Fix YAML formatting for SALESFORCE vendor extension data (use block scalar instead of quoted string)

## Test plan
- [ ] Verify the example validates against `osi-schema.json`
- [ ] Run `python validation/validate.py examples/tpcds_semantic_model.yaml`