### PR TITLE
Add personal data and confidentiality indicators (fixes #58, #59)

### DIFF
--- a/core-spec/osi-schema.json
+++ b/core-spec/osi-schema.json
@@ -155,6 +155,14 @@
           "type": "string",
           "description": "Human-readable description"
         },
+        "contains_personal_data": {
+          "type": "boolean",
+          "description": "Indicates if this field contains personal data (PII) subject to privacy regulations"
+        },
+        "is_confidential": {
+          "type": "boolean",
+          "description": "Indicates if this field contains confidential information that should not be exposed to LLMs or external tools"
+        },
         "ai_context": {
           "$ref": "#/$defs/AIContext"
         },
@@ -200,6 +208,14 @@
         "description": {
           "type": "string",
           "description": "Human-readable description"
+        },
+        "contains_personal_data": {
+          "type": "boolean",
+          "description": "Indicates if this dataset contains personal data (PII) subject to privacy regulations"
+        },
+        "is_confidential": {
+          "type": "boolean",
+          "description": "Indicates if this dataset contains confidential information that should not be exposed to LLMs or external tools"
         },
         "ai_context": {
           "$ref": "#/$defs/AIContext"

--- a/core-spec/spec.md
+++ b/core-spec/spec.md
@@ -95,6 +95,8 @@ Logical datasets represent business entities or concepts (fact and dimension tab
 | `primary_key` | array | No | Primary key columns that uniquely identify rows (single or composite) |
 | `unique_keys` | array of arrays | No | Array of unique key definitions (each can be single or composite) |
 | `description` | string | No | Human-readable description |
+| `contains_personal_data` | boolean | No | Indicates if this dataset contains personal data (PII) subject to privacy regulations |
+| `is_confidential` | boolean | No | Indicates if this dataset contains confidential information that should not be exposed to LLMs or external tools |
 | `ai_context` | string/object | No | Additional context for AI tools (e.g., synonyms, common terms) |
 | `fields` | array | No | Row-level attributes for grouping, filtering, and metric expressions |
 | `custom_extensions` | array | No | Vendor-specific attributes |
@@ -137,6 +139,20 @@ datasets:
     custom_extensions:
       - vendor_name: DBT
         data: '{"materialized": "table"}'
+
+  - name: customers
+    source: sales.public.customers
+    primary_key: [customer_id]
+    description: Customer information including PII
+    contains_personal_data: true  # Dataset contains personal identifiable information
+    fields: []
+
+  - name: financial_records
+    source: finance.private.records
+    primary_key: [record_id]
+    description: Sensitive financial records
+    is_confidential: true  # Dataset should not be exposed to LLMs
+    fields: []
 ```
 
 ---
@@ -202,6 +218,8 @@ Fields represent row-level attributes that can be used for grouping, filtering, 
 | `dimension` | object | No | Dimension metadata (e.g., `is_time` flag) |
 | `label` | string | No | Label for categorization |
 | `description` | string | No | Human-readable description |
+| `contains_personal_data` | boolean | No | Indicates if this field contains personal data (PII) subject to privacy regulations |
+| `is_confidential` | boolean | No | Indicates if this field contains confidential information that should not be exposed to LLMs or external tools |
 | `ai_context` | string/object | No | Additional context for AI tools (e.g., synonyms) |
 | `custom_extensions` | array | No | Vendor-specific attributes |
 
@@ -287,6 +305,34 @@ expression:
       - dialect: SNOWFLAKE
         expression: LOWER(email)::VARCHAR
   description: Normalized email address
+```
+
+**Field with Personal Data:**
+
+```yaml
+- name: email
+  expression:
+    dialects:
+      - dialect: ANSI_SQL
+        expression: email
+  description: Customer email address
+  contains_personal_data: true  # Field contains PII
+  ai_context:
+    synonyms:
+      - "email address"
+      - "contact email"
+```
+
+**Confidential Field:**
+
+```yaml
+- name: ssn
+  expression:
+    dialects:
+      - dialect: ANSI_SQL
+        expression: social_security_number
+  description: Social security number
+  is_confidential: true  # Field should not be exposed to LLMs
 ```
 
 ---

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -99,6 +99,12 @@ datasets:
     # Optional: Human-readable description of the logical dataset
     description: string
 
+    # Optional: Indicates if this dataset contains personal data (PII) subject to privacy regulations
+    contains_personal_data: boolean
+
+    # Optional: Indicates if this dataset contains confidential information that should not be exposed to LLMs or external tools
+    is_confidential: boolean
+
     # Optional: Additional context for AI tools (e.g., synonyms, common terms)
     # Helps LLMs understand the business meaning and generate better queries
     ai_context: string
@@ -177,6 +183,12 @@ fields:
 
     # Optional: Human-readable description of the field
     description: string
+
+    # Optional: Indicates if this field contains personal data (PII) subject to privacy regulations
+    contains_personal_data: boolean
+
+    # Optional: Indicates if this field contains confidential information that should not be exposed to LLMs or external tools
+    is_confidential: boolean
 
     # Optional: Additional context for AI tools (e.g., synonyms, business terms)
     # Helps LLMs understand the field meaning and generate better queries

--- a/examples/sensitivity_example.yaml
+++ b/examples/sensitivity_example.yaml
@@ -1,0 +1,117 @@
+# yaml-language-server: $schema=../core-spec/osi-schema.json
+
+# Example demonstrating the use of data sensitivity attributes
+# Shows how to mark fields and datasets with contains_personal_data and is_confidential flags
+
+version: "1.0"
+
+semantic_model:
+  - name: customer_analytics
+    description: Customer data with sensitivity markings
+    ai_context:
+      instructions: "Use this model for customer analytics. Note that some fields contain personal data or confidential information."
+
+    datasets:
+      # Dataset with personal data marking
+      - name: customers
+        source: sales.public.customers
+        primary_key: [customer_id]
+        description: Customer information including PII
+        contains_personal_data: true  # Dataset contains personal identifiable information
+        fields:
+          - name: customer_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: customer_id
+            description: Customer identifier
+
+          - name: email
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: email
+            description: Customer email address
+            contains_personal_data: true  # Field contains PII
+            ai_context:
+              synonyms:
+                - "email address"
+                - "contact email"
+
+          - name: phone_number
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: phone_number
+            description: Customer phone number
+            contains_personal_data: true  # Field contains PII
+
+      # Dataset with confidential marking
+      - name: financial_records
+        source: finance.private.records
+        primary_key: [record_id]
+        description: Sensitive financial records
+        is_confidential: true  # Dataset should not be exposed to LLMs
+        fields:
+          - name: record_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: record_id
+            description: Record identifier
+
+          - name: ssn
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: social_security_number
+            description: Social security number
+            is_confidential: true  # Field should not be exposed to LLMs
+            contains_personal_data: true  # Also PII
+
+          - name: account_balance
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: account_balance
+            description: Account balance
+            is_confidential: true  # Confidential financial information
+
+      # Dataset without sensitivity markings
+      - name: products
+        source: catalog.public.products
+        primary_key: [product_id]
+        description: Product catalog information
+        fields:
+          - name: product_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: product_id
+            description: Product identifier
+
+          - name: product_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: product_name
+            description: Product name
+
+    relationships:
+      - name: customers_to_financial_records
+        from: financial_records
+        to: customers
+        from_columns: [record_id]
+        to_columns: [customer_id]
+
+    metrics:
+      - name: total_customers
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: COUNT(DISTINCT customers.customer_id)
+        description: Total number of customers
+        ai_context:
+          synonyms:
+            - "customer count"
+            - "number of customers"


### PR DESCRIPTION
## Summary

This PR implements two feature requests:
- Fixes #58 - New attribute: contain personal data
- Fixes #59 - New attribute: confidential indicator

## Changes

Added two new optional boolean attributes to both `Field` and `Dataset` schemas:

| Attribute | Purpose |
|-----------|---------|
| `contains_personal_data` | Flags fields/datasets containing PII for privacy compliance (GDPR, CCPA) |
| `is_confidential` | Indicates data that should not be exposed to LLMs or external tools |

## Files Modified

- `core-spec/osi-schema.json` - JSON Schema definitions
- `core-spec/spec.yaml` - YAML specification
- `core-spec/spec.md` - Documentation with examples

## Example Usage

```yaml
fields:
  - name: email
    expression:
      dialects:
        - dialect: ANSI_SQL
          expression: email
    contains_personal_data: true
    is_confidential: false
    
  - name: ssn
    expression:
      dialects:
        - dialect: ANSI_SQL
          expression: social_security_number
    contains_personal_data: true
    is_confidential: true
```