### PR TITLE
Add CLA Assistant workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,32 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+permissions:
+  actions: write
+  contents: write 
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/open-semantic-interchange/OSI/blob/main/cla/CLA.md'
+          # branch should not be protected
+          branch: 'cla-signatures'
+          allowlist: bot*
+          custom-notsigned-prcomment: |
+            🚫 **CLA Required**
+            Thanks for your contribution! Before this PR can be reviewed or merged, please read and sign the [CLA](https://github.com/open-semantic-interchange/OSI/blob/main/cla/CLA.md) by commenting:
+          custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for CLA Assistant (`cla.yml`)
- Automatically prompts contributors to sign the CLA on pull requests
- Points to the CLA document in this repository