### PR TITLE
Small syntax bugfix for `spec.yaml`

### DIFF
--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -46,7 +46,7 @@ semantic_model:
 
     # Optional: Defines how logical datasets are connected
     # See Relationships section below for detailed structure
-    relationships:[]
+    relationships: []
 
     # Optional: 
     # These metrics can span one or more logical datasets and use relationships


### PR DESCRIPTION
The `semantic_model.relationships` entry didn't have a space after the `:`. This is technically mandatory, and some parsers can't read the file without it.