### PR TITLE
Change vendor_name from enum to free-form string

### DIFF
--- a/core-spec/osi-schema.json
+++ b/core-spec/osi-schema.json
@@ -19,7 +19,7 @@
     },
     "vendors": {
       "type": "array",
-      "description": "Supported vendors for custom extensions (enumeration definition)",
+      "description": "Well-known vendors for custom extensions (non-exhaustive list of examples)",
       "items": {
         "$ref": "#/$defs/Vendor"
       }

--- a/core-spec/osi-schema.json
+++ b/core-spec/osi-schema.json
@@ -42,8 +42,8 @@
     },
     "Vendor": {
       "type": "string",
-      "enum": ["COMMON", "SNOWFLAKE", "SALESFORCE", "DBT", "DATABRICKS", "GOODDATA"],
-      "description": "Supported vendors for custom extensions"
+      "examples": ["COMMON", "SNOWFLAKE", "SALESFORCE", "DBT", "DATABRICKS", "GOODDATA"],
+      "description": "Vendor name for custom extensions. Any string value is accepted."
     },
     "AIContext": {
       "description": "Additional context for AI tools",

--- a/core-spec/osi-schema.json
+++ b/core-spec/osi-schema.json
@@ -19,7 +19,7 @@
     },
     "vendors": {
       "type": "array",
-      "description": "Well-known vendors for custom extensions (non-exhaustive list of examples)",
+      "description": "List of vendor names used in custom extensions within this model",
       "items": {
         "$ref": "#/$defs/Vendor"
       }

--- a/core-spec/osi-schema.json
+++ b/core-spec/osi-schema.json
@@ -42,8 +42,8 @@
     },
     "Vendor": {
       "type": "string",
-      "enum": ["COMMON", "SNOWFLAKE", "SALESFORCE", "DBT", "DATABRICKS"],
-      "description": "Supported vendors for custom extensions"
+      "examples": ["COMMON", "SNOWFLAKE", "SALESFORCE", "DBT", "DATABRICKS"],
+      "description": "Vendor name for custom extensions. Any string value is accepted."
     },
     "AIContext": {
       "description": "Additional context for AI tools",

--- a/core-spec/spec.md
+++ b/core-spec/spec.md
@@ -363,7 +363,7 @@ Custom extensions allow vendors to add platform-specific metadata without breaki
 
 ```yaml
 custom_extensions:
-  - vendor_name: string  # Must be from vendors enum
+  - vendor_name: string  # Free-form string identifying the vendor
     data: string         # JSON string containing vendor-specific data
 ```
 

--- a/core-spec/spec.md
+++ b/core-spec/spec.md
@@ -41,7 +41,10 @@ Supported SQL and expression language dialects for metrics and field definitions
 
 ### Vendors
 
-Supported vendors for custom extensions and integrations.
+The `vendor_name` field is a free-form string, allowing any vendor or organization to
+define custom extensions without requiring changes to the core specification.
+
+The following are well-known examples:
 
 | Vendor | Description |
 |--------|-------------|

--- a/core-spec/spec.md
+++ b/core-spec/spec.md
@@ -38,7 +38,10 @@ Supported SQL and expression language dialects for metrics and field definitions
 
 ### Vendors
 
-Supported vendors for custom extensions and integrations.
+The `vendor_name` field is a free-form string, allowing any vendor or organization to
+define custom extensions without requiring changes to the core specification.
+
+The following are well-known examples:
 
 | Vendor | Description |
 |--------|-------------|

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -22,14 +22,9 @@ dialects:
 
 
 
-# Supported vendors for custom extensions
-vendors:
-  - "COMMON"
-  - "SNOWFLAKE"
-  - "SALESFORCE"
-  - "DBT"
-  - "DATABRICKS"
-  - "GOODDATA"
+# Vendor name for custom extensions (free-form string)
+# Examples: "COMMON", "SNOWFLAKE", "SALESFORCE", "DBT", "DATABRICKS", "GOODDATA"
+vendor_name: string
 
  
 # Top-level semantic model definition

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -20,13 +20,9 @@ dialects:
 
 
 
-# Supported vendors for custom extensions
-vendors:
-  - "COMMON"
-  - "SNOWFLAKE"
-  - "SALESFORCE"
-  - "DBT"
-  - "DATABRICKS"
+# Vendor name for custom extensions (free-form string)
+# Examples: "COMMON", "SNOWFLAKE", "SALESFORCE", "DBT", "DATABRICKS"
+vendor_name: string
 
  
 # Top-level semantic model definition


### PR DESCRIPTION
## Summary
- Change `vendor_name` in custom extensions from a closed enum to a free-form string, allowing any vendor or organization to define custom extensions without modifying the core spec
- Existing vendor names (COMMON, SNOWFLAKE, SALESFORCE, DBT, DATABRICKS) are preserved as `examples` in the JSON Schema and documented as well-known examples in the spec
- Updated `spec.yaml`, `osi-schema.json`, and `spec.md`


🤖 Generated with [Claude Code](https://claude.com/claude-code)