### PR TITLE
salesforce: copy core-spec/osi-schema.json into classpath at build time

### DIFF
--- a/converters/salesforce/pom.xml
+++ b/converters/salesforce/pom.xml
@@ -25,6 +25,7 @@
         <logback.version>1.5.25</logback.version>
         <json-schema-validator.version>1.5.5</json-schema-validator.version>
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
+        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     </properties>
 
     <dependencies>
@@ -69,6 +70,39 @@
 
     <build>
         <plugins>
+            <!--
+              Copy the canonical OSI core-spec JSON schema into this module's
+              classpath under /schemas/osi-schema.json so SchemaValidator can
+              load it at runtime. Single source of truth lives in
+              ../../core-spec/osi-schema.json; do not maintain a duplicate
+              copy in this module's src/main/resources.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven-resources-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-osi-core-spec-schema</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}/schemas</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/../../core-spec</directory>
+                                    <includes>
+                                        <include>osi-schema.json</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
## Summary

In the Salesforce converter module: `SchemaValidator` loads the OSI core schema from classpath at `/schemas/osi-schema.json`, but **no such file was ever checked into `src/main/resources/schemas/`**. 

This PR wires `maven-resources-plugin` to copy the canonical `core-spec/osi-schema.json` into `target/classes/schemas/osi-schema.json` during the `process-resources` phase. Single source of truth stays in `core-spec/`; no duplicate file to drift.

## Verification — `mvn clean test`

| | Before | After |
|---|---|---|
| Tests run | 28 | 28 |
| Executed | 0 | **14** |
| Skipped | 28 | 14 |
| Failures | 0 | **0** |

The 14 still-skipped tests require the upstream Salesforce schema (`salesforce-semantic-model-schema.json`), which the existing test code documents as a manual download from Salesforce's site. That's a separate concern out of scope here.

