### PR TITLE
docs: expand README with repo overview and contribution pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The **Open Semantic Interchange (OSI)** initiative is a collaborative, open-source effort dedicated to standardizing and streamlining semantic model exchange and utilization across the diverse array of tools and platforms within the data analytics, AI, and BI ecosystem. Our shared vision is to establish a common, vendor-agnostic semantic model specification, promoting unparalleled interoperability, efficiency, and collaboration among all participants. By providing a single, consistent source of truth, this vendor-agnostic standard ensures that your data's definitions and value remain consistent as they are interchanged between AI agents, BI platforms, and all other tools in your ecosystem, eliminating inconsistencies across your different tools.
 
-OSI addresses semantic fragmentation — the same KPI defined differently across tools, teams spending significant effort manually reconciling definitions, and AI agents producing unreliable outputs grounded in inconsistent business logic — by providing a single JSON- and YAML-based specification that any tool can read and write.
+OSI provides a single JSON- and YAML-based specification that any tool can read and write, addressing the semantic fragmentation common across today's data stack: the same KPI defined differently across tools, teams spending significant effort manually reconciling definitions, and AI agents producing unreliable outputs grounded in inconsistent business logic.
 
 ## What's in this repository
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 # OSI
-The OSI initiative is a collaborative, open-source effort dedicated to standardizing and streamlining semantic model exchange and utilization across the diverse array of tools and platforms within the data analytics, AI, and BI ecosystem. Our shared vision is to establish a common, vendor-agnostic semantic model specification, promoting unparalleled interoperability, efficiency, and collaboration among all participants. By providing a single, consistent source of truth, this vendor-agnostic standard ensures that your data’s definitions and value remain consistent as they are interchanged between AI agents, BI platforms, and all other tools in your ecosystem, eliminating inconsistencies across your different tools.
 
+The **Open Semantic Interchange (OSI)** initiative is a collaborative, open-source effort dedicated to standardizing and streamlining semantic model exchange and utilization across the diverse array of tools and platforms within the data analytics, AI, and BI ecosystem. Our shared vision is to establish a common, vendor-agnostic semantic model specification, promoting unparalleled interoperability, efficiency, and collaboration among all participants. By providing a single, consistent source of truth, this vendor-agnostic standard ensures that your data's definitions and value remain consistent as they are interchanged between AI agents, BI platforms, and all other tools in your ecosystem, eliminating inconsistencies across your different tools.
+
+OSI addresses semantic fragmentation — where the same KPI is defined differently across tools, teams spend significant effort manually reconciling definitions, and AI agents produce unreliable outputs grounded in inconsistent business logic — by providing a single YAML-based specification that any tool can read and write.
+
+## What's in this repository
+
+- [`core-spec/`](core-spec/) — The OSI core specification (`spec.md`), the machine-readable schema (`spec.yaml`, `osi-schema.json`), and accompanying documentation.
+- [`converters/`](converters/) — Reference converters that translate between OSI and other semantic formats (e.g., dbt, GoodData, Polaris, Salesforce).
+- [`examples/`](examples/) — Example semantic models, including a complete TPC-DS model.
+- [`validation/`](validation/) — Tooling for validating semantic models against the OSI schema.
+- [`docs/`](docs/) — Project documentation and overview.
+
+## Get involved
+
+- **Contribute:** See [CONTRIBUTING.md](CONTRIBUTING.md) for how to propose specification changes, contribute code, and participate in the community.
+- **Roadmap:** See [ROADMAP.md](ROADMAP.md) for current working groups, future efforts, and planned enhancements informed by community discussion.
+- **Discuss:** Join the conversation on [GitHub Discussions](https://github.com/open-semantic-interchange/OSI/discussions) and [Issues](https://github.com/open-semantic-interchange/OSI/issues).
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The **Open Semantic Interchange (OSI)** initiative is a collaborative, open-source effort dedicated to standardizing and streamlining semantic model exchange and utilization across the diverse array of tools and platforms within the data analytics, AI, and BI ecosystem. Our shared vision is to establish a common, vendor-agnostic semantic model specification, promoting unparalleled interoperability, efficiency, and collaboration among all participants. By providing a single, consistent source of truth, this vendor-agnostic standard ensures that your data's definitions and value remain consistent as they are interchanged between AI agents, BI platforms, and all other tools in your ecosystem, eliminating inconsistencies across your different tools.
 
-OSI addresses semantic fragmentation — where the same KPI is defined differently across tools, teams spend significant effort manually reconciling definitions, and AI agents produce unreliable outputs grounded in inconsistent business logic — by providing a single YAML-based specification that any tool can read and write.
+OSI addresses semantic fragmentation — the same KPI defined differently across tools, teams spending significant effort manually reconciling definitions, and AI agents producing unreliable outputs grounded in inconsistent business logic — by providing a single JSON- and YAML-based specification that any tool can read and write.
 
 ## What's in this repository
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ OSI provides a single JSON- and YAML-based specification that any tool can read 
 - **Contribute:** See [CONTRIBUTING.md](CONTRIBUTING.md) for how to propose specification changes, contribute code, and participate in the community.
 - **Roadmap:** See [ROADMAP.md](ROADMAP.md) for current working groups, future efforts, and planned enhancements informed by community discussion.
 - **Discuss:** Join the conversation on [GitHub Discussions](https://github.com/open-semantic-interchange/OSI/discussions) and [Issues](https://github.com/open-semantic-interchange/OSI/issues).
+- **Chat:** Join the community on [Slack](https://join.slack.com/t/opensemanticx/shared_invite/zt-3pq1j0lid-tQBbEvAngAvz0I0vZm~HJw).
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ OSI provides a single JSON- and YAML-based specification that any tool can read 
 - **Contribute:** See [CONTRIBUTING.md](CONTRIBUTING.md) for how to propose specification changes, contribute code, and participate in the community.
 - **Roadmap:** See [ROADMAP.md](ROADMAP.md) for current working groups, future efforts, and planned enhancements informed by community discussion.
 - **Discuss:** Join the conversation on [GitHub Discussions](https://github.com/open-semantic-interchange/OSI/discussions) and [Issues](https://github.com/open-semantic-interchange/OSI/issues).
-- **Chat:** Join the community on [Slack](https://join.slack.com/t/opensemanticx/shared_invite/zt-3pq1j0lid-tQBbEvAngAvz0I0vZm~HJw).
+- **Join the Slack community:** Chat directly with contributors on [Slack](https://join.slack.com/t/opensemanticx/shared_invite/zt-3pq1j0lid-tQBbEvAngAvz0I0vZm~HJw).
 
 # License
 


### PR DESCRIPTION
## Summary
- Slightly expand the README intro with a sentence framing the problem OSI solves.
- Add a "What's in this repository" section pointing to `core-spec/`, `converters/`, `examples/`, `validation/`, and `docs/`.
- Add a "Get involved" section linking to `CONTRIBUTING.md`, `ROADMAP.md`, and the GitHub Discussions/Issues boards so new contributors can easily find how to participate and what's planned.

