### PR TITLE
Remove top-level dialects and vendors from the json schema

### DIFF
--- a/core-spec/osi-schema.json
+++ b/core-spec/osi-schema.json
@@ -10,20 +10,6 @@
       "const": "0.2.0.dev0",
       "description": "OSI specification version"
     },
-    "dialects": {
-      "type": "array",
-      "description": "Supported expression language dialects (enumeration definition)",
-      "items": {
-        "$ref": "#/$defs/Dialect"
-      }
-    },
-    "vendors": {
-      "type": "array",
-      "description": "List of vendor names used in custom extensions within this model",
-      "items": {
-        "$ref": "#/$defs/Vendor"
-      }
-    },
     "semantic_model": {
       "type": "array",
       "description": "Collection of semantic model definitions",

--- a/core-spec/spec.md
+++ b/core-spec/spec.md
@@ -39,22 +39,6 @@ Supported SQL and expression language dialects for metrics and field definitions
 | `DATABRICKS` | Databricks SQL |
 | `MAQL` | GoodData MAQL (Metric Analysis and Query Language) |
 
-### Vendors
-
-The `vendor_name` field is a free-form string, allowing any vendor or organization to
-define custom extensions without requiring changes to the core specification.
-
-The following are well-known examples:
-
-| Vendor | Description |
-|--------|-------------|
-| `COMMON` | Common/standard extensions |
-| `SNOWFLAKE` | Snowflake-specific attributes |
-| `SALESFORCE` | Salesforce/Tableau-specific attributes |
-| `DBT` | dbt-specific attributes |
-| `DATABRICKS` | Databricks-specific attributes |
-| `GOODDATA` | GoodData-specific attributes |
-
 ## Semantic Model
 
 The top-level container that represents a complete semantic model, including datasets, relationships, and  metrics.
@@ -366,6 +350,22 @@ custom_extensions:
   - vendor_name: string  # Free-form string identifying the vendor
     data: string         # JSON string containing vendor-specific data
 ```
+
+### Vendor Names
+
+The `vendor_name` field is a free-form string, allowing any vendor or organization to
+define custom extensions without requiring changes to the core specification.
+
+The following are well-known examples:
+
+| Vendor | Description |
+|--------|-------------|
+| `COMMON` | Common/standard extensions |
+| `SNOWFLAKE` | Snowflake-specific attributes |
+| `SALESFORCE` | Salesforce/Tableau-specific attributes |
+| `DBT` | dbt-specific attributes |
+| `DATABRICKS` | Databricks-specific attributes |
+| `GOODDATA` | GoodData-specific attributes |
 
 ### Examples
 

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -54,7 +54,7 @@ semantic_model:
     # Optional: Vendor-specific attributes for extensibility
     # Allows vendors to add custom metadata without breaking core compatibility
     custom_extensions:
-      - vendor_name: string  # Must be one of the values from 'vendors' enum above
+      - vendor_name: string  # Free-form string identifying the vendor
         data: string
 
 ---
@@ -107,7 +107,7 @@ datasets:
 
     # Optional: Vendor-specific attributes for extensibility
     custom_extensions:
-      - vendor_name: string  # Must be one of the values from 'vendors' enum above
+      - vendor_name: string  # Free-form string identifying the vendor
         data: string
 
 ---
@@ -144,7 +144,7 @@ relationships:
 
     # Optional: Vendor-specific attributes for extensibility
     custom_extensions:
-      - vendor_name: string  # Must be one of the values from 'vendors' enum above
+      - vendor_name: string  # Free-form string identifying the vendor
         data: string
 
 ---
@@ -182,7 +182,7 @@ fields:
 
      # Optional: Vendor-specific attributes for extensibility
     custom_extensions:
-      - vendor_name: string  # Must be one of the values from 'vendors' enum above
+      - vendor_name: string  # Free-form string identifying the vendor
         data: string
 
 ---
@@ -211,5 +211,5 @@ metrics:
 
      # Optional: Vendor-specific attributes for extensibility
     custom_extensions:
-      - vendor_name: string  # Must be one of the values from 'vendors' enum above
+      - vendor_name: string  # Free-form string identifying the vendor
         data: string


### PR DESCRIPTION
## Summary
- Remove unused top-level `dialects` and `vendors` properties from `core-spec/osi-schema.json`
- Root schema now contains only `version` and `semantic_model` (both required)
- `Dialect` and `Vendor` `$defs` are retained for use within `Expression` and custom extensions

## Why
- These top-level arrays were never referenced by `examples/tpcds_semantic_model.yaml` or by `validation/validate.py`
- `validate.py` reads dialects from each expression's per-dialect entries via `$defs/Expression`, not from the root
- Keeps the root schema minimal and focused

## Test plan
- [x] Ran `python3 validation/validate.py examples/tpcds_semantic_model.yaml` -> `Validation PASSED`
- [x] Converter tests

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
