### PR TITLE
Refresh expired Slack invite link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ We welcome contributions from everyone — whether you are a developer, a data e
 2. **Explore the Examples**: Review the [TPC-DS example](examples/tpcds_semantic_model.yaml) to see a complete semantic model in practice.
 3. **Join the Conversation**: Open or participate in [GitHub Issues](https://github.com/open-semantic-interchange) and Discussions to share ideas and feedback.
 4. **Submit a Pull Request**: Fork the repository, make your changes, and submit a pull request. All contributions go through the standard review process described below.
-5. **Join the Slack workspace**: Chat directly with the community by [joining Slack](https://join.slack.com/t/opensemanticx/shared_invite/zt-3pq1j0lid-tQBbEvAngAvz0I0vZm~HJw).
+5. **Join the Slack workspace**: Chat directly with the community by [joining Slack](https://join.slack.com/t/opensemanticx/shared_invite/zt-3yuad6c0h-MaoPgVSD1g9MEOf1_QeaiQ).
 
 ## Contribution Guidelines
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ OSI provides a single JSON- and YAML-based specification that any tool can read 
 - **Contribute:** See [CONTRIBUTING.md](CONTRIBUTING.md) for how to propose specification changes, contribute code, and participate in the community.
 - **Roadmap:** See [ROADMAP.md](ROADMAP.md) for current working groups, future efforts, and planned enhancements informed by community discussion.
 - **Discuss:** Join the conversation on [GitHub Discussions](https://github.com/open-semantic-interchange/OSI/discussions) and [Issues](https://github.com/open-semantic-interchange/OSI/issues).
-- **Join the Slack community:** Chat directly with contributors on [Slack](https://join.slack.com/t/opensemanticx/shared_invite/zt-3pq1j0lid-tQBbEvAngAvz0I0vZm~HJw).
+- **Join the Slack community:** Chat directly with contributors on [Slack](https://join.slack.com/t/opensemanticx/shared_invite/zt-3yuad6c0h-MaoPgVSD1g9MEOf1_QeaiQ).
 
 # License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -319,7 +319,7 @@ A practical guide for organizations looking to adopt OSI.
 
 - **Website**: [open-semantic-interchange.org](https://open-semantic-interchange.org/)
 - **GitHub**: [github.com/open-semantic-interchange](https://github.com/open-semantic-interchange)
-- **Slack**: [join slack](https://join.slack.com/t/opensemanticx/shared_invite/zt-3pq1j0lid-tQBbEvAngAvz0I0vZm~HJw)
+- **Slack**: [join slack](https://join.slack.com/t/opensemanticx/shared_invite/zt-3yuad6c0h-MaoPgVSD1g9MEOf1_QeaiQ)
 - **Core Specification**: [core-spec/spec.md](../core-spec/spec.md)
 - **JSON Schema**: [core-spec/osi-schema.json](../core-spec/osi-schema.json)
 - **YAML Schema**: [core-spec/spec.yaml](../core-spec/spec.yaml)
@@ -347,7 +347,7 @@ We welcome contributions from everyone — whether you are a developer, a data e
 2. **Explore the Examples**: Review the [TPC-DS example](../examples/tpcds_semantic_model.yaml) to see a complete semantic model in practice.
 3. **Join the Conversation**: Open or participate in [GitHub Issues](https://github.com/open-semantic-interchange) and Discussions to share ideas and feedback.
 4. **Submit a Pull Request**: Fork the repository, make your changes, and submit a pull request. All contributions go through the standard review process described in the governance section above.
-5. **Join the Slack workspace**: You can chat directly with the community by [joining Slack](https://join.slack.com/t/opensemanticx/shared_invite/zt-3pq1j0lid-tQBbEvAngAvz0I0vZm~HJw).
+5. **Join the Slack workspace**: You can chat directly with the community by [joining Slack](https://join.slack.com/t/opensemanticx/shared_invite/zt-3yuad6c0h-MaoPgVSD1g9MEOf1_QeaiQ).
 
 ### Code of Conduct
 

--- a/docs/working_groups.md
+++ b/docs/working_groups.md
@@ -1,6 +1,6 @@
 # OSI Working Groups
 
-Join the community on Slack: [join.slack.com/t/opensemanticx](https://join.slack.com/t/opensemanticx/shared_invite/zt-3pq1j0lid-tQBbEvAngAvz0I0vZm~HJw)
+Join the community on Slack: [join.slack.com/t/opensemanticx](https://join.slack.com/t/opensemanticx/shared_invite/zt-3yuad6c0h-MaoPgVSD1g9MEOf1_QeaiQ)
 
 ## 1. Metric Language and Relationships
 

--- a/docs/working_groups.md
+++ b/docs/working_groups.md
@@ -7,7 +7,7 @@ Join the community on Slack: [join.slack.com/t/opensemanticx](https://join.slack
 | | |
 |---|---|
 | **Lead** | Will Pugh |
-| **Slack channel** | `#wg-metric-language` |
+| **Slack channel** | `#metric-language-working-group` |
 | **Google Calendar** | _link TBD_ |
 
 ## 2. Composability
@@ -31,7 +31,7 @@ Join the community on Slack: [join.slack.com/t/opensemanticx](https://join.slack
 | | |
 |---|---|
 | **Lead** | Kurt (Relational AI) |
-| **Slack channel** | `#wg-ontology` |
+| **Slack channel** | `#osi-ontology` |
 | **Google Calendar** | _link TBD_ |
 
 ## 5. Sync API


### PR DESCRIPTION
## Summary
- The current Slack invite link (`zt-3pq1j0lid-...`) has expired.
- Replace it with the new invite link (`zt-3yuad6c0h-...`) in all 4 files where it appears: `README.md`, `CONTRIBUTING.md`, `docs/index.md`, and `docs/working_groups.md`.

