### PR TITLE
Add BIGQUERY to the Dialect enum

### DIFF
--- a/core-spec/osi-schema.json
+++ b/core-spec/osi-schema.json
@@ -23,7 +23,7 @@
   "$defs": {
     "Dialect": {
       "type": "string",
-      "enum": ["ANSI_SQL", "SNOWFLAKE", "MDX", "TABLEAU", "DATABRICKS", "MAQL"],
+      "enum": ["ANSI_SQL", "SNOWFLAKE", "MDX", "TABLEAU", "DATABRICKS", "MAQL", "BIGQUERY"],
       "description": "Supported SQL and expression language dialects"
     },
     "Vendor": {

--- a/core-spec/spec.md
+++ b/core-spec/spec.md
@@ -38,6 +38,7 @@ Supported SQL and expression language dialects for metrics and field definitions
 | `TABLEAU` | Tableau calculations |
 | `DATABRICKS` | Databricks SQL |
 | `MAQL` | GoodData MAQL (Metric Analysis and Query Language) |
+| `BIGQUERY` | Google BigQuery (GoogleSQL) |
 
 ## Semantic Model
 
@@ -278,6 +279,8 @@ expression:
         expression: LOWER(email)
       - dialect: SNOWFLAKE
         expression: LOWER(email)::VARCHAR
+      - dialect: BIGQUERY
+        expression: SAFE_CAST(LOWER(email) AS STRING)
   description: Normalized email address
 ```
 

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -19,6 +19,7 @@ dialects:
   - "TABLEAU"               # Tableau
   - "DATABRICKS"            # Databricks SQL
   - "MAQL"                  # GoodData MAQL (Multi-Dimensional Analytical Query Language)
+  - "BIGQUERY"              # Google BigQuery GoogleSQL
 
 
 


### PR DESCRIPTION
Adds BIGQUERY (GoogleSQL) as a supported expression dialect alongside the existing ANSI_SQL, SNOWFLAKE, MDX, TABLEAU, DATABRICKS, and MAQL values.

- core-spec/osi-schema.json: add BIGQUERY to the Dialect enum
- core-spec/spec.yaml: add BIGQUERY to the dialects list
- core-spec/spec.md: add BIGQUERY to the dialect table and the multi-dialect field example (SAFE_CAST GoogleSQL form)