### PR TITLE
Ontology: Drop Float as a built-in concept

### DIFF
--- a/examples/flights.yaml
+++ b/examples/flights.yaml
@@ -14,8 +14,8 @@ ontology:
         multiplicity: ManyToOne
       - name: shapelength
         roles:
-          - concept: Float
-        verbalizes: [ '{Example_Runway} shapeLength {Float}' ]
+          - concept: Decimal
+        verbalizes: [ '{Example_Runway} shapeLength {Decimal}' ]
         multiplicity: ManyToOne
       - name: airportid
         roles:
@@ -24,8 +24,8 @@ ontology:
         multiplicity: ManyToOne
       - name: length
         roles:
-          - concept: Float
-        verbalizes: [ '{Example_Runway} length {Float}' ]
+          - concept: Decimal
+        verbalizes: [ '{Example_Runway} length {Decimal}' ]
         multiplicity: ManyToOne
       - name: geometry
         roles:
@@ -1071,7 +1071,7 @@ ontology_mappings:
                   expression: Example_Runway_example_runway.id
             children:
               - object_mapping:
-                  concept: Float
+                  concept: Decimal
                   expression: Example_Runway_example_runway.length
                 relationship: length
               - object_mapping:
@@ -1083,7 +1083,7 @@ ontology_mappings:
                   expression: Example_Runway_example_runway.designator
                 relationship: designator
               - object_mapping:
-                  concept: Float
+                  concept: Decimal
                   expression: Example_Runway_example_runway.shape_length
                 relationship: shape_length
               - object_mapping:

--- a/ontology/ontology.md
+++ b/ontology/ontology.md
@@ -43,7 +43,6 @@ Ontologies come with several built in concepts that can be referred to by name:
 | `Date` | Most general date value type |
 | `DateTime` | Most general datetime value type |
 | `Decimal` | Most general decimal value type |
-| `Float` | Most general floating point value type |
 | `Integer` | Most general integer value type |
 | `String` | Most general string value type |
 


### PR DESCRIPTION
## Summary

`Float` and `Decimal` describe the same thing at the conceptual level: the most general floating-point/decimal value type. Carrying both as separate built-in concepts is redundant and invites ambiguity about which one to extend when modeling a non-integer numeric value type.

This PR drops `Float` as a built-in concept and keeps `Decimal` as the single built-in for non-integer numeric values.

## Changes

- `ontology/ontology.md`: remove the `Float` row from the built-in concepts table.
- `examples/flights.yaml`: update the runway `length` and `shapeLength` mappings (and their verbalizations) to use `Decimal` instead of `Float`, so the example still references only declared built-ins.

## Notes

No JSON schema or validation code enumerated the built-in concepts, so the doc table and the one example were the only references to `Float`.