### PR TITLE
feat(dbt): add ossie plugin adapter

### DIFF
--- a/converters/dbt/bin/convert
+++ b/converters/dbt/bin/convert
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# OSSIE plugin entry point for the dbt converter.
+# The OSSIE CLI sets CWD to the plugin directory before invoking this script,
+# so relative paths resolve against the plugin root.
+exec .venv/bin/python src/osi_dbt/ossie_plugin.py "$@"

--- a/converters/dbt/bin/setup
+++ b/converters/dbt/bin/setup
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Creates a venv and installs the dbt converter and its dependencies.
+# Run once after installing the plugin. CWD must be the plugin root.
+set -euo pipefail
+
+python3 -m venv .venv
+
+# osi-python is a local dev package not yet published to PyPI.
+# When running from the source tree, install from the sibling python/ directory.
+# When installed as a plugin (no source tree present), install from GitHub.
+OSI_PYTHON_LOCAL="../../python"
+if [ -d "$OSI_PYTHON_LOCAL" ]; then
+    .venv/bin/pip install -e "$OSI_PYTHON_LOCAL" --quiet
+else
+    .venv/bin/pip install \
+        "git+https://github.com/open-semantic-interchange/OSI#subdirectory=python" \
+        --quiet
+fi
+
+.venv/bin/pip install -e . --quiet

--- a/converters/dbt/plugin.yaml
+++ b/converters/dbt/plugin.yaml
@@ -1,0 +1,12 @@
+ossie_plugin_spec: "0.1.0"
+ossie_spec_version: ">=0.2.0"
+platform:
+  name: dbt
+  vendor: dbt Labs
+setup: bin/setup
+convert:
+  to_osi:
+    invoke: ["bin/convert", "to-osi"]
+    accepts: [".json"]
+  from_osi:
+    invoke: ["bin/convert", "from-osi"]

--- a/converters/dbt/src/osi_dbt/ossie_plugin.py
+++ b/converters/dbt/src/osi_dbt/ossie_plugin.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""OSSIE I/O protocol adapter for the dbt converter.
+
+Reads a JSON request from stdin:
+    {"files": {"name": "<utf-8 content>", ...}}
+
+Writes a JSON response to stdout:
+    {"files": {"name": "<content>", ...}, "issues": [...]}
+
+All debug output goes to stderr. Stdout is reserved for the response.
+"""
+import json
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) != 2 or sys.argv[1] not in ("to-osi", "from-osi"):
+        print(f"usage: {sys.argv[0]} <to-osi|from-osi>", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        request = json.load(sys.stdin)
+    except Exception as e:
+        print(f"failed to parse request: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    files = request.get("files", {})
+    direction = sys.argv[1]
+
+    if direction == "to-osi":
+        response = to_osi(files)
+    else:
+        response = from_osi(files)
+
+    json.dump(response, sys.stdout)
+
+
+def to_osi(files: dict) -> dict:
+    """Convert dbt semantic_manifest.json → OSI YAML."""
+    manifest_content = next(
+        (v for k, v in files.items() if k.endswith(".json")), None
+    )
+    if manifest_content is None:
+        return _error("no .json input file found; expected a dbt semantic_manifest.json")
+
+    try:
+        from metricflow_semantics.model.dbt_manifest_parser import (
+            parse_manifest_from_dbt_generated_manifest,
+        )
+        from osi_dbt import MSIToOSIConverter
+
+        manifest = parse_manifest_from_dbt_generated_manifest(manifest_content)
+        result = MSIToOSIConverter().convert(manifest, osi_model_name="semantic_model")
+    except Exception as e:
+        return _error(str(e))
+
+    return {
+        "files": {"semantic_model.yaml": result.output.to_osi_yaml()},
+        "issues": [_map_issue(i) for i in result.issues],
+    }
+
+
+def from_osi(files: dict) -> dict:
+    """Convert OSI YAML → dbt semantic_manifest.json."""
+    yaml_content = next(
+        (v for k, v in files.items() if k.endswith((".yaml", ".yml"))), None
+    )
+    if yaml_content is None:
+        return _error("no .yaml input file found; expected an OSI YAML document")
+
+    try:
+        import yaml
+        from osi import OSIDocument
+        from osi_dbt import OSIToMSIConverter
+
+        raw = yaml.safe_load(yaml_content)
+        doc = OSIDocument.model_validate(raw)
+        result = OSIToMSIConverter().convert(doc)
+    except Exception as e:
+        return _error(str(e))
+
+    # PydanticSemanticManifest uses pydantic v1 compat (.json(), not .model_dump_json()).
+    manifest_json = result.output.json(by_alias=True, exclude_none=True, indent=2)
+    return {
+        "files": {"semantic_manifest.json": manifest_json},
+        "issues": [_map_issue(i) for i in result.issues],
+    }
+
+
+def _map_issue(issue) -> dict:
+    from osi_dbt import ConverterIssueType
+
+    severity = {
+        ConverterIssueType.CONVERSION_METRIC_DROPPED: "warning",
+        ConverterIssueType.PRIVATE_METRIC_DROPPED: "warning",
+        ConverterIssueType.NATURAL_ENTITY_DROPPED: "warning",
+        ConverterIssueType.CUMULATIVE_SEMANTICS_LOSS: "info",
+    }.get(issue.issue_type, "warning")
+
+    return {
+        "severity": severity,
+        "message": f"{issue.issue_type.value}: {issue.element_name}",
+        "path": issue.element_name,
+    }
+
+
+def _error(message: str) -> dict:
+    return {"files": {}, "issues": [{"severity": "error", "message": message}]}
+
+
+if __name__ == "__main__":
+    main()

--- a/converters/dbt/tests/test_ossie_plugin.py
+++ b/converters/dbt/tests/test_ossie_plugin.py
@@ -1,0 +1,119 @@
+"""Tests for the OSSIE I/O protocol adapter (ossie_plugin.py).
+
+Each test mocks sys.stdin/sys.stdout/sys.argv and calls main() directly,
+asserting the JSON response matches the expected shape.
+"""
+import io
+import json
+import sys
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+import pytest
+
+from osi_dbt.ossie_plugin import from_osi, to_osi
+from tests.helpers import (
+    _dimension,
+    _entity,
+    _manifest,
+    _measure,
+    _osi_doc,
+    _osi_dataset,
+    _osi_field,
+    _simple_metric,
+)
+from metricflow_semantic_interfaces.implementations.semantic_model import (
+    PydanticNodeRelation,
+    PydanticSemanticModel,
+)
+from metricflow_semantic_interfaces.type_enums import DimensionType, EntityType
+from metricflow_semantic_interfaces.test_utils import default_meta
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_manifest_json() -> str:
+    """Serialize a minimal but valid PydanticSemanticManifest to JSON."""
+    entity = _entity("order_id", EntityType.PRIMARY)
+    measure = _measure("order_count", expr="1")
+    dimension = _dimension("is_cancelled", DimensionType.CATEGORICAL)
+    sm = PydanticSemanticModel(
+        name="orders",
+        node_relation=PydanticNodeRelation(alias="orders", schema_name="public", database="analytics"),
+        description="Order records",
+        entities=[entity],
+        measures=[measure],
+        dimensions=[dimension],
+        metadata=default_meta(),
+        config=None,
+    )
+    metric = _simple_metric("order_count", "order_count")
+    manifest = _manifest(semantic_models=[sm], metrics=[metric])
+    # PydanticSemanticManifest uses pydantic v1 compat (.json(), not .model_dump_json()).
+    return manifest.json(by_alias=True, exclude_none=True)
+
+
+def _minimal_osi_yaml() -> str:
+    """Serialize a minimal OSIDocument to YAML."""
+    doc = _osi_doc(
+        datasets=[_osi_dataset("orders", fields=[_osi_field("order_id")])],
+        model_name="test",
+    )
+    return doc.to_osi_yaml()
+
+
+# ---------------------------------------------------------------------------
+# to_osi tests
+# ---------------------------------------------------------------------------
+
+
+def test_to_osi_no_json_file_returns_error_issue():
+    response = to_osi({"model.yaml": "version: 1"})
+    assert response["files"] == {}
+    assert len(response["issues"]) == 1
+    assert response["issues"][0]["severity"] == "error"
+
+
+def test_to_osi_real_manifest_produces_osi_yaml():
+    manifest_json = _minimal_manifest_json()
+    response = to_osi({"semantic_manifest.json": manifest_json})
+
+    assert response["files"], "expected output files"
+    assert "semantic_model.yaml" in response["files"]
+
+    osi_yaml = response["files"]["semantic_model.yaml"]
+    assert "semantic_model" in osi_yaml, "expected OSI YAML with semantic_model key"
+
+
+def test_to_osi_response_has_no_errors_for_simple_manifest():
+    manifest_json = _minimal_manifest_json()
+    response = to_osi({"semantic_manifest.json": manifest_json})
+
+    error_issues = [i for i in response["issues"] if i["severity"] == "error"]
+    assert error_issues == [], f"unexpected errors: {error_issues}"
+
+
+# ---------------------------------------------------------------------------
+# from_osi tests
+# ---------------------------------------------------------------------------
+
+
+def test_from_osi_no_yaml_file_returns_error_issue():
+    response = from_osi({"manifest.json": "{}"})
+    assert response["files"] == {}
+    assert len(response["issues"]) == 1
+    assert response["issues"][0]["severity"] == "error"
+
+
+def test_from_osi_real_osi_yaml_produces_manifest():
+    osi_yaml = _minimal_osi_yaml()
+    response = from_osi({"model.yaml": osi_yaml})
+
+    assert response["files"], "expected output files"
+    assert "semantic_manifest.json" in response["files"]
+
+    manifest = json.loads(response["files"]["semantic_manifest.json"])
+    assert "semantic_models" in manifest, "expected semantic_models in output manifest"


### PR DESCRIPTION
## Summary

Adapts the existing dbt converter to speak the OSSIE CLI's stdin/stdout JSON protocol, making it the first real plugin the CLI can invoke end-to-end.

- `plugin.yaml` — OSSIE plugin manifest declaring platform `dbt`, `bin/setup`, and both conversion directions
- `bin/setup` — creates a venv and installs the package; uses local `osi-python` from the source tree during development, falls back to GitHub install when deployed
- `bin/convert` — thin bash wrapper that invokes `ossie_plugin.py` via the venv Python
- `src/osi_dbt/ossie_plugin.py` — protocol adapter: reads JSON request from stdin, calls `MSIToOSIConverter` or `OSIToMSIConverter`, writes JSON response to stdout

No changes to existing converter logic.

## Test locally

```shell
# Set up the venv (from repo root)
cd converters/dbt && bin/setup

# Run a conversion using --plugin to bypass discovery
make -C cli install
ossie convert --from dbt \
  --plugin converters/dbt \
  --input path/to/semantic_manifest.json
```

Output lands in `./ossie-output/dbt/to_osi/semantic_model.yaml`.

## Test plan

- [ ] `bin/setup` completes and creates `.venv/`
- [ ] `echo '{"files":{}}' | .venv/bin/python src/osi_dbt/ossie_plugin.py to-osi` returns error issue (no .json file)
- [ ] `.venv/bin/python -m pytest tests/test_ossie_plugin.py` — all 5 tests pass
- [ ] `ossie convert --from dbt --plugin converters/dbt --input <manifest.json>` produces `ossie-output/dbt/to_osi/semantic_model.yaml`
- [ ] `ossie convert --to dbt --plugin converters/dbt --input <osi.yaml>` produces `ossie-output/dbt/from_osi/semantic_manifest.json`