### PR TITLE
Update Slack join link to apache-ossie workspace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ We welcome contributions from everyone — whether you are a developer, a data e
 2. **Explore the Examples**: Review the [TPC-DS example](examples/tpcds_semantic_model.yaml) to see a complete semantic model in practice.
 3. **Join the Conversation**: Open or participate in [GitHub Issues](https://github.com/open-semantic-interchange) and Discussions to share ideas and feedback.
 4. **Submit a Pull Request**: Fork the repository, make your changes, and submit a pull request. All contributions go through the standard review process described below.
-5. **Join the Slack workspace**: Chat directly with the community by [joining Slack](https://join.slack.com/t/opensemanticx/shared_invite/zt-3yuad6c0h-MaoPgVSD1g9MEOf1_QeaiQ).
+5. **Join the Slack workspace**: Chat directly with the community by [joining Slack](https://join.slack.com/t/apache-ossie/shared_invite/zt-42i1xkgy8-7YQtKEDq7v~mceFmdiLhkA).
 
 ## Contribution Guidelines
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ OSI provides a single JSON- and YAML-based specification that any tool can read 
 - **Contribute:** See [CONTRIBUTING.md](CONTRIBUTING.md) for how to propose specification changes, contribute code, and participate in the community.
 - **Roadmap:** See [ROADMAP.md](ROADMAP.md) for current working groups, future efforts, and planned enhancements informed by community discussion.
 - **Discuss:** Join the conversation on [GitHub Discussions](https://github.com/open-semantic-interchange/OSI/discussions) and [Issues](https://github.com/open-semantic-interchange/OSI/issues).
-- **Join the Slack community:** Chat directly with contributors on [Slack](https://join.slack.com/t/opensemanticx/shared_invite/zt-3yuad6c0h-MaoPgVSD1g9MEOf1_QeaiQ).
+- **Join the Slack community:** Chat directly with contributors on [Slack](https://join.slack.com/t/apache-ossie/shared_invite/zt-42i1xkgy8-7YQtKEDq7v~mceFmdiLhkA).
 
 # License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -319,7 +319,7 @@ A practical guide for organizations looking to adopt OSI.
 
 - **Website**: [open-semantic-interchange.org](https://open-semantic-interchange.org/)
 - **GitHub**: [github.com/open-semantic-interchange](https://github.com/open-semantic-interchange)
-- **Slack**: [join slack](https://join.slack.com/t/opensemanticx/shared_invite/zt-3yuad6c0h-MaoPgVSD1g9MEOf1_QeaiQ)
+- **Slack**: [join slack](https://join.slack.com/t/apache-ossie/shared_invite/zt-42i1xkgy8-7YQtKEDq7v~mceFmdiLhkA)
 - **Core Specification**: [core-spec/spec.md](../core-spec/spec.md)
 - **JSON Schema**: [core-spec/osi-schema.json](../core-spec/osi-schema.json)
 - **YAML Schema**: [core-spec/spec.yaml](../core-spec/spec.yaml)
@@ -347,7 +347,7 @@ We welcome contributions from everyone — whether you are a developer, a data e
 2. **Explore the Examples**: Review the [TPC-DS example](../examples/tpcds_semantic_model.yaml) to see a complete semantic model in practice.
 3. **Join the Conversation**: Open or participate in [GitHub Issues](https://github.com/open-semantic-interchange) and Discussions to share ideas and feedback.
 4. **Submit a Pull Request**: Fork the repository, make your changes, and submit a pull request. All contributions go through the standard review process described in the governance section above.
-5. **Join the Slack workspace**: You can chat directly with the community by [joining Slack](https://join.slack.com/t/opensemanticx/shared_invite/zt-3yuad6c0h-MaoPgVSD1g9MEOf1_QeaiQ).
+5. **Join the Slack workspace**: You can chat directly with the community by [joining Slack](https://join.slack.com/t/apache-ossie/shared_invite/zt-42i1xkgy8-7YQtKEDq7v~mceFmdiLhkA).
 
 ### Code of Conduct
 

--- a/docs/working_groups.md
+++ b/docs/working_groups.md
@@ -1,6 +1,6 @@
 # OSI Working Groups
 
-Join the community on Slack: [join.slack.com/t/opensemanticx](https://join.slack.com/t/opensemanticx/shared_invite/zt-3yuad6c0h-MaoPgVSD1g9MEOf1_QeaiQ)
+Join the community on Slack: [join.slack.com/t/opensemanticx](https://join.slack.com/t/apache-ossie/shared_invite/zt-42i1xkgy8-7YQtKEDq7v~mceFmdiLhkA)
 
 ## 1. Metric Language and Relationships
 


### PR DESCRIPTION
## Summary

- Updated Slack invite link from the old `opensemanticx` workspace to the new `apache-ossie` workspace
- Changed in 4 files: `README.md`, `CONTRIBUTING.md`, `docs/index.md`, `docs/working_groups.md` (5 occurrences total)

New link: https://join.slack.com/t/apache-ossie/shared_invite/zt-42i1xkgy8-7YQtKEDq7v~mceFmdiLhkA

## Test plan

- [ ] Verify each updated link opens the correct Slack workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)