### PR TITLE
python: accept free-form custom extension vendors

### DIFF
--- a/converters/README.md
+++ b/converters/README.md
@@ -281,7 +281,7 @@ Given the [TPC-DS example](../examples/tpcds_semantic_model.yaml) included in th
 
 To add support for a new vendor:
 
-1. Add the vendor to the `vendors` enum in the [core specification](../core-spec/spec.md) if not already present.
+1. Use a stable `vendor_name` string in each custom extension emitted by the converter.
 2. Define the custom extension schema for the vendor (what vendor-specific metadata fields are supported in the `data` JSON).
 3. Implement the export converter (Ossie → Vendor).
 4. Implement the import converter (Vendor → Ossie).

--- a/python/src/ossie/models.py
+++ b/python/src/ossie/models.py
@@ -35,7 +35,7 @@ class OSIDialect(str, Enum):
 
 
 class OSIVendor(str, Enum):
-    """Vendors with supported custom extensions."""
+    """Well-known vendor names for custom extensions."""
 
     COMMON = "COMMON"
     SNOWFLAKE = "SNOWFLAKE"
@@ -63,7 +63,7 @@ class OSICustomExtension(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    vendor_name: OSIVendor
+    vendor_name: str
     data: str
 
 


### PR DESCRIPTION
Custom extension vendor names are free-form strings in the current spec and JSON schema, but the Python package still types OSICustomExtension.vendor_name as the OSIVendor enum. A document that is valid against osi-schema.json, e.g. a custom extension with vendor_name: ACME, is rejected by the Python model.

#91 relaxed vendor_name to a free-form string in the spec and schema but did not update the Python package, so the package is now stricter than the spec it implements.

Change vendor_name to str. OSIVendor stays as well-known constants, and since it is a str enum, comparisons like vendor_name == "DBT" still work. Also fix the converter guide, which still tells contributors to add new vendors to a core enum.

Does not touch root dialects/vendors (#148 covers that). Verified locally that the old model rejects vendor_name: ACME and the new one accepts and round-trips it.