### PR TITLE
docs: flag repository as legacy, point to apache/ossie

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 # Contributing to Open Semantic Interchange (OSI)
 
+> [!IMPORTANT]
+> **This repository is legacy and will be archived.** The project has moved to [apache/ossie](https://github.com/apache/ossie). Please direct new contributions there.
+
 We welcome contributions from everyone — whether you are a developer, a data engineer, a BI analyst, or simply someone interested in the future of semantic interoperability.
 
 ## Ways to Contribute

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # OSI
 
+> [!IMPORTANT]
+> **This repository is legacy and will be archived.** The project has moved to [apache/ossie](https://github.com/apache/ossie). Please direct new work, issues, and contributions there.
+
 The **Open Semantic Interchange (OSI)** initiative is a collaborative, open-source effort dedicated to standardizing and streamlining semantic model exchange and utilization across the diverse array of tools and platforms within the data analytics, AI, and BI ecosystem. Our shared vision is to establish a common, vendor-agnostic semantic model specification, promoting unparalleled interoperability, efficiency, and collaboration among all participants. By providing a single, consistent source of truth, this vendor-agnostic standard ensures that your data's definitions and value remain consistent as they are interchanged between AI agents, BI platforms, and all other tools in your ecosystem, eliminating inconsistencies across your different tools.
 
 OSI provides a single JSON- and YAML-based specification that any tool can read and write, addressing the semantic fragmentation common across today's data stack: the same KPI defined differently across tools, teams spending significant effort manually reconciling definitions, and AI agents producing unreliable outputs grounded in inconsistent business logic.


### PR DESCRIPTION
## Summary
- This repository is legacy and will be archived; the project has moved to [apache/ossie](https://github.com/apache/ossie).
- Adds a callout at the top of the README so contributors and users landing here know to direct new work, issues, and contributions to apache/ossie instead.

## Test plan
- [x] Rendered README locally to confirm the callout formats correctly on GitHub (`> [!IMPORTANT]` admonition)