### PR TITLE
feat(python): add bigquery dialect

### DIFF
--- a/python/src/ossie/models.py
+++ b/python/src/ossie/models.py
@@ -31,6 +31,7 @@ class OSIDialect(str, Enum):
     MAQL = "MAQL"
     TABLEAU = "TABLEAU"
     DATABRICKS = "DATABRICKS"
+    BIGQUERY = "BIGQUERY"
 
 
 class OSIVendor(str, Enum):

--- a/validation/validate.py
+++ b/validation/validate.py
@@ -55,6 +55,7 @@ DIALECT_MAP = {
     "ANSI_SQL": None,  # sqlglot default
     "SNOWFLAKE": "snowflake",
     "DATABRICKS": "databricks",
+    "BIGQUERY": "bigquery",
     "MDX": None,  # Not supported by sqlglot, skip validation
     "TABLEAU": None,  # Not supported by sqlglot, skip validation
     "MAQL": None,  # Not supported by sqlglot, skip validation


### PR DESCRIPTION
- Add BigQuery to `OSIDialect` in `python/src/ossie/models.py`.
- Add BigQuery to `DIALECT_MAP` in `validation/validate.py`.

This is a follow-up to https://github.com/apache/ossie/pull/143.