### PR TITLE
Fix Polaris converter build

### DIFF
--- a/converters/polaris/pom.xml
+++ b/converters/polaris/pom.xml
@@ -41,6 +41,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <snakeyaml.version>2.2</snakeyaml.version>
         <jackson.version>2.17.0</jackson.version>


### PR DESCRIPTION
Currently the maven.compiler.releases is set to java8:
```
➜  polaris git:(main) mvn help:effective-pom -Dverbose | grep maven.compiler.release
    <maven.compiler.release>8</maven.compiler.release>  <!-- org.apache:apache:39, line 585 -->
```

This failed the compiled as `java.net.http` is not in java8 (https://openjdk.org/groups/net/httpclient/):
```
[ERROR] /Users/yong/Desktop/GitHome/ossie/converters/polaris/src/main/java/org/apache/ossie/converter/polaris/PolarisClient.java:[29,21] package java.net.http does not exist
[ERROR] /Users/yong/Desktop/GitHome/ossie/converters/polaris/src/main/java/org/apache/ossie/converter/polaris/PolarisClient.java:[30,21] package java.net.http does not exist
[ERROR] /Users/yong/Desktop/GitHome/ossie/converters/polaris/src/main/java/org/apache/ossie/converter/polaris/PolarisClient.java:[31,21] package java.net.http does not exist
```

With the change in this PR, I am now able to build the project:
```
➜  polaris git:(fix_polaris_converter_build) mvn clean package
[INFO] Scanning for projects...
[INFO]
[INFO] --------------< org.apache.ossie:ossie-polaris-converter >--------------
[INFO] Building Apache Ossie Polaris Converter 0.1.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- clean:3.5.0:clean (default-clean) @ ossie-polaris-converter ---
[INFO]
[INFO] --- enforcer:3.6.3:enforce (enforce-maven-version) @ ossie-polaris-converter ---
[INFO] Rule 0: org.apache.maven.enforcer.rules.version.RequireMavenVersion passed
[INFO]
[INFO] --- enforcer:3.6.3:enforce (enforce-java-version) @ ossie-polaris-converter ---
[INFO] Rule 0: org.apache.maven.enforcer.rules.version.RequireJavaVersion passed
[INFO]
[INFO] --- remote-resources:3.3.0:process (process-resource-bundles) @ ossie-polaris-converter ---
[INFO] Preparing remote bundle org.apache.apache.resources:apache-jar-resource-bundle:1.8
[INFO] Copying 3 resources from 1 bundle.
[INFO]
[INFO] --- resources:3.5.0:resources (default-resources) @ ossie-polaris-converter ---
[INFO] skip non existing resourceDirectory /Users/yong/Desktop/GitHome/ossie/converters/polaris/src/main/resources
[INFO] Copying 3 resources from target/maven-shared-archive-resources to target/classes
[INFO]
[INFO] --- compiler:3.15.0:compile (default-compile) @ ossie-polaris-converter ---
[INFO] Recompiling the module because of changed source code.
[INFO] Compiling 7 source files with javac [debug release 11] to target/classes
[INFO]
[INFO] --- resources:3.5.0:testResources (default-testResources) @ ossie-polaris-converter ---
[INFO] skip non existing resourceDirectory /Users/yong/Desktop/GitHome/ossie/converters/polaris/src/test/resources
[INFO] Copying 3 resources from target/maven-shared-archive-resources to target/test-classes
[INFO]
[INFO] --- compiler:3.15.0:testCompile (default-testCompile) @ ossie-polaris-converter ---
[INFO] Recompiling the module because of changed dependency.
[INFO] Compiling 1 source file with javac [debug release 11] to target/test-classes
[INFO]
[INFO] --- surefire:3.5.6:test (default-test) @ ossie-polaris-converter ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.ossie.converter.polaris.OsiPolarisConverterTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.294 s -- in org.apache.ossie.converter.polaris.OsiPolarisConverterTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- jar:3.3.0:jar (default-jar) @ ossie-polaris-converter ---
[INFO] Building jar: /Users/yong/Desktop/GitHome/ossie/converters/polaris/target/ossie-polaris-converter-0.1.0-SNAPSHOT.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.552 s
[INFO] Finished at: 2026-07-11T15:56:28-05:00
[INFO] ------------------------------------------------------------------------
➜  polaris git:(fix_polaris_converter_build) ✗
```