### PR TITLE
feat(python models): Add version support for python models

### DIFF
--- a/python/src/ossie/__init__.py
+++ b/python/src/ossie/__init__.py
@@ -15,6 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("apache-ossie")
+except PackageNotFoundError:
+    __version__ = "unknown"
+
 from ossie.models import (
     OSIAIContext,
     OSIAIContextObject,


### PR DESCRIPTION
Not sure if we want to add this, currently we can get version by looking at pip freeze...I am wondering if it makes senses to add standard `__version__` support here:
```
(venv) ➜  python git:(python_add_version_support) ✗ python3
Python 3.13.0 (v3.13.0:60403a5409f, Oct  7 2024, 00:37:40) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import ossie; ossie.__version__
'0.2.0.dev0'
```

This is more nice to have convention but may not be necessary for spec library. Thoughts?