### PR TITLE
add semantido as a ossie vendor

### DIFF
--- a/python/src/ossie/models.py
+++ b/python/src/ossie/models.py
@@ -43,6 +43,7 @@ class OSIVendor(str, Enum):
     DBT = "DBT"
     DATABRICKS = "DATABRICKS"
     GOODDATA = "GOODDATA"
+    SEMANTIDO = "SEMANTIDO"
 
 
 class OSIAIContextObject(BaseModel):


### PR DESCRIPTION
semantido is a code-native semantic layer authoring for SQLAlchemy. Annotate your models where they live, and generate LLM-ready schema context for text-to-SQL agents, RAG pipelines, and BI tools either as JSON, Markdown, or vendor-neutral [OSI](https://open-semantic-interchange.org/) YAML.

This is the first PR to add semantido as a vendor. The next will be to add semantido to the converters. You can see an example of an OSI exported semantic layer for a trade reporting schema here: https://github.com/hikarilabs/semantido/blob/main/examples/01_getting_started/exports/trade_reporting.osi.yaml

An article describing the v0.3.0 release including the osi-exporter can be found here: https://dragoscrintea.me/articles/semantics-where-the-code-lives-interchange-where-the-stack-lives