### PR TITLE
Make the spec's own examples validate against osi-schema.json

### DIFF
--- a/core-spec/spec.md
+++ b/core-spec/spec.md
@@ -83,7 +83,9 @@ semantic_model:
     description: Sales and customer analytics model
     ai_context:
       instructions: "Use this model for sales analysis and customer insights"
-    datasets: []
+    datasets:
+      - name: orders
+        source: sales.public.orders
     relationships: []
     metrics: []
     custom_extensions:
@@ -337,8 +339,9 @@ expression:
 ```yaml
 - name: total_revenue
   expression:
-    - dialect: ANSI_SQL
-      expression: SUM(orders.amount)
+    dialects:
+      - dialect: ANSI_SQL
+        expression: SUM(orders.amount)
   description: Total revenue across all orders
   ai_context:
     synonyms:
@@ -351,8 +354,9 @@ expression:
 ```yaml
 - name: avg_orders
   expression:
-    - dialect: ANSI_SQL
-      expression: SUM(orders.amount) / COUNT(DISTINCT customers.id)
+    dialects:
+      - dialect: ANSI_SQL
+        expression: SUM(orders.amount) / COUNT(DISTINCT customers.id)
   description: Average orders
   ai_context:
     synonyms:
@@ -445,6 +449,7 @@ The following are well-known examples:
 Here's a complete semantic model example showing all components working together:
 
 ```yaml
+version: 0.2.0.dev0
 semantic_model:
   - name: ecommerce_analytics
     description: E-commerce sales and customer analytics

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -91,11 +91,9 @@ datasets:
     # Can be a single column or a composite of multiple columns
     # This is the preferred unique identifier for this dataset and is used in relationships to determine many-to-one or one-to-one.
     # Examples:
-    # primary_key:
-    #   - [customer_id]           # Simple primary key
+    # primary_key: [customer_id]            # Simple primary key
     #
-    # primary_key:
-    #   - [order_id, line_number] # Composite primary key
+    # primary_key: [order_id, line_number]  # Composite primary key
     primary_key: []  # Array of column names (single or composite)
 
     # Optional: Array of unique key definitions that uniquely identify rows in this dataset


### PR DESCRIPTION
Four small fixes so the examples in core-spec agree with the rules osi-schema.json already states:

1. The Semantic Model section example used `datasets: []`, which violates the schema's `minItems: 1`; it now carries one minimal dataset.
2. Both metric examples (`total_revenue`, `avg_orders`) wrote `expression:` as a bare list, omitting the required `dialects` wrapper that the Expression Object section directly above them defines. They now match the schema and the Complete Example.
3. The Complete Example presented a full document without the required top-level `version` key; it now begins with `version: 0.2.0.dev0`.
4. `spec.yaml`'s commented `primary_key` examples showed a nested list (`- [customer_id]`) while the schema defines `primary_key` as a flat array of strings; the comments now show the flat form used by the schema and by spec.md's own inline examples.

Verification: extracted each fixed example and ran it through `validation/validate.py` (JSON Schema, name uniqueness, relationship references, sqlglot SQL checks) — all pass, including the Complete Example verbatim as a full document.

Found while building an OSI exporter for a governed semantic-layer tool; happy to adjust scope if the section examples are intentionally fragments.