### PR TITLE
Fix converter dbt pytest

### DIFF
--- a/converters/dbt/pyproject.toml
+++ b/converters/dbt/pyproject.toml
@@ -51,5 +51,10 @@ dev-dependencies = [
     "syrupy>=4.0",
 ]
 
+# apache-ossie is not yet published to PyPI; resolve it from the in-repo
+# package for now. Remove this block once apache-ossie published to PyPI.
+[tool.uv.sources]
+apache-ossie = { path = "../../python", editable = true}
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
The current dbt converter is depends on `"apache-ossie>=0.2.0.dev0"` which is not yet published to PyPI. This would throw resolving error when running `uv sync`:
```
➜  dbt git:(main) uv sync
...
Creating virtual environment at: .venv
  × No solution found when resolving dependencies:
  ╰─▶ Because apache-ossie was not found in the package registry and your project depends on apache-ossie>=0.2.0.dev0, we can conclude that your project's requirements
      are unsatisfiable.

```

And here is the output with this temporary fix:
```
➜  dbt git:(fix_converter_dbt_uv_test) uv sync
...
Resolved 31 packages in 235ms
      Built apache-ossie @ file:///Users/yong/Desktop/GitHome/ossie/python
      Built apache-ossie-dbt @ file:///Users/yong/Desktop/GitHome/ossie/converters/dbt
Prepared 16 packages in 354ms
Installed 30 packages in 61ms
 + annotated-types==0.7.0
 + apache-ossie==0.2.0.dev0 (from file:///Users/yong/Desktop/GitHome/ossie/python)
 + apache-ossie-dbt==0.2.0.dev0 (from file:///Users/yong/Desktop/GitHome/ossie/converters/dbt)
 + attrs==26.1.0
 + importlib-metadata==9.0.0
 + iniconfig==2.3.0
 + jinja2==3.1.6
 + jsonschema==4.26.0
 + jsonschema-specifications==2025.9.1
 + markupsafe==3.0.3
 + metricflow==0.211.0
 + more-itertools==10.8.0
 + packaging==26.2
 + pluggy==1.6.0
 + pydantic==2.13.4
 + pydantic-core==2.46.4
 + pygments==2.20.0
 + pytest==9.1.1
 + python-dateutil==2.9.0.post0
 + pyyaml==6.0.3
 + rapidfuzz==3.14.5
 + referencing==0.37.0
 + rpds-py==2026.6.3
 + six==1.17.0
 + sqlglot==30.12.0
 + syrupy==5.5.3
 + tabulate==0.10.0
 + typing-extensions==4.16.0
 + typing-inspection==0.4.2
 + zipp==4.1.0
```

And here is the validation for pytest after fixing uv sync issue:
```
➜  dbt git:(fix_converter_dbt_uv_test) ✗ uv run pytest
warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.11.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/yong/Desktop/GitHome/ossie/converters/dbt
configfile: pyproject.toml
testpaths: tests
plugins: syrupy-5.5.3
collected 94 items

tests/test_msi_to_osi.py ..................................................................                                                                        [ 70%]
tests/test_osi_to_msi.py ............................                                                                                                              [100%]

------------------------------------------------------------------------ snapshot report summary -------------------------------------------------------------------------
5 snapshots passed.
=========================================================================== 94 passed in 0.26s ===========================================================================
```