### PR TITLE
chore: add EditorConfig tab indentation for Go files, go.mod, and Makefile

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,3 +30,6 @@ indent_size = 2
 [*.{py,java,toml}]
 indent_style = space
 indent_size = 4
+
+[{Makefile,go.mod,*.go}]
+indent_style = tab


### PR DESCRIPTION
Add EditorConfig tab indentation for Go files, `go.mod`, and `Makefile`.