### PR TITLE
chore(cli): add gofmt format target to Makefile

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,7 +1,7 @@
 BINARY_NAME := ossie
 BUILD_DIR   := dist
 
-.PHONY: build test lint release-dry-run clean
+.PHONY: build test lint format release-dry-run clean
 
 build:
 	go build -o $(BUILD_DIR)/$(BINARY_NAME) .
@@ -11,6 +11,9 @@ test:
 
 lint:
 	go vet ./...
+
+format:
+	gofmt -w .
 
 release-dry-run:
 	goreleaser release --snapshot --clean --config .goreleaser.yaml

--- a/cli/internal/ossiedir/ossiedir.go
+++ b/cli/internal/ossiedir/ossiedir.go
@@ -8,8 +8,8 @@ import (
 
 const (
 	defaultOssieDir = ".ossie"
-	pluginsSubdir = "plugins"
-	envVar        = "OSSIE_PLUGIN_DIR"
+	pluginsSubdir   = "plugins"
+	envVar          = "OSSIE_PLUGIN_DIR"
 )
 
 // PluginDir returns the resolved plugin directory path.


### PR DESCRIPTION
- Add a `format` target that runs `gofmt -w .` and register it in `.PHONY`.
- Apply gofmt alignment to the const block in `ossiedir.go`.