### PR TITLE
Check in snapshot files for consistent testing

### DIFF
--- a/converters/dbt/README.md
+++ b/converters/dbt/README.md
@@ -133,9 +133,3 @@ cd converters/dbt
 uv sync
 uv run pytest
 ```
-
-Generate initial syrupy snapshots on first run:
-
-```bash
-uv run pytest --snapshot-update
-```

--- a/converters/dbt/README.md
+++ b/converters/dbt/README.md
@@ -133,3 +133,8 @@ cd converters/dbt
 uv sync
 uv run pytest
 ```
+
+Generate new Syrupy snapshots:
+```bash
+uv run pytest --snapshot-update
+```

--- a/converters/dbt/tests/__snapshots__/test_msi_to_osi.ambr
+++ b/converters/dbt/tests/__snapshots__/test_msi_to_osi.ambr
@@ -1,0 +1,184 @@
+# serializer version: 1
+# name: TestMetricConversion.test_derived_metric_nested
+  '''
+  version: 0.2.0.dev0
+  dialects:
+  - ANSI_SQL
+  semantic_model:
+  - name: semantic_model
+    datasets:
+    - name: orders
+      source: schema.table
+      fields:
+      - name: revenue
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: amount
+      - name: cost
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: cost_amount
+      - name: expenses
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: expense_amount
+    metrics:
+    - name: revenue
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM(orders.amount)
+    - name: cost
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM(orders.cost_amount)
+    - name: expenses
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM(orders.expense_amount)
+    - name: gross_profit
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM(orders.amount) - SUM(orders.cost_amount)
+    - name: net_profit
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: (SUM(orders.amount) - SUM(orders.cost_amount)) - SUM(orders.expense_amount)
+  
+  '''
+# ---
+# name: TestMetricConversion.test_ratio_metric_inlines_sub_expressions
+  '''
+  version: 0.2.0.dev0
+  dialects:
+  - ANSI_SQL
+  semantic_model:
+  - name: semantic_model
+    datasets:
+    - name: orders
+      source: schema.table
+      fields:
+      - name: revenue
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: amount
+      - name: order_count
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: CASE WHEN order_id IS NOT NULL THEN 1 ELSE 0 END
+    metrics:
+    - name: revenue
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM(orders.amount)
+    - name: order_count
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM(CASE WHEN orders.order_id IS NOT NULL THEN 1 ELSE 0 END)
+    - name: arpu
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: (SUM(orders.amount)) / (SUM(CASE WHEN orders.order_id IS NOT NULL
+            THEN 1 ELSE 0 END))
+  
+  '''
+# ---
+# name: TestMetricFilterFlattening.test_metric_and_measure_filters_combined_with_and
+  '''
+  version: 0.2.0.dev0
+  dialects:
+  - ANSI_SQL
+  semantic_model:
+  - name: semantic_model
+    datasets:
+    - name: orders
+      source: schema.table
+      fields:
+      - name: revenue
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: amount
+    metrics:
+    - name: paid_intl_revenue
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM(CASE WHEN (status = 'paid') AND (region = 'intl') THEN orders.amount
+            END)
+  
+  '''
+# ---
+# name: TestRelationshipConversion.test_three_datasets_produce_all_pairs
+  '''
+  version: 0.2.0.dev0
+  dialects:
+  - ANSI_SQL
+  semantic_model:
+  - name: semantic_model
+    datasets:
+    - name: users_a
+      source: schema.table
+      primary_key:
+      - user_id
+      fields:
+      - name: user
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: user_id
+    - name: users_b
+      source: schema.table
+      unique_keys:
+      - - user_id
+      fields:
+      - name: user
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: user_id
+    - name: orders
+      source: schema.table
+      fields:
+      - name: user
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: user_id
+    relationships:
+    - name: users_a__users_b__user
+      from: users_a
+      to: users_b
+      from_columns:
+      - user_id
+      to_columns:
+      - user_id
+    - name: orders__users_a__user
+      from: orders
+      to: users_a
+      from_columns:
+      - user_id
+      to_columns:
+      - user_id
+    - name: orders__users_b__user
+      from: orders
+      to: users_b
+      from_columns:
+      - user_id
+      to_columns:
+      - user_id
+  
+  '''
+# ---

--- a/converters/dbt/tests/__snapshots__/test_msi_to_osi.ambr
+++ b/converters/dbt/tests/__snapshots__/test_msi_to_osi.ambr
@@ -1,4 +1,20 @@
 # serializer version: 1
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 # name: TestMetricConversion.test_derived_metric_nested
   '''
   version: 0.2.0.dev0

--- a/converters/dbt/tests/__snapshots__/test_osi_to_msi.ambr
+++ b/converters/dbt/tests/__snapshots__/test_osi_to_msi.ambr
@@ -1,0 +1,49 @@
+# serializer version: 1
+# name: TestOSIToMSIRoundTrip.test_osi_to_msi_to_osi_preserves_structure
+  '''
+  version: 0.2.0.dev0
+  dialects:
+  - ANSI_SQL
+  semantic_model:
+  - name: semantic_model
+    datasets:
+    - name: orders
+      source: analytics.orders
+      primary_key:
+      - order_id
+      fields:
+      - name: order_id
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: order_id
+      - name: status
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: status
+        dimension:
+          is_time: false
+      - name: created_at
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: created_at
+        dimension:
+          is_time: true
+      - name: amount
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: amount
+        dimension:
+          is_time: false
+    metrics:
+    - name: revenue
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM(orders.amount)
+  
+  '''
+# ---

--- a/converters/dbt/tests/__snapshots__/test_osi_to_msi.ambr
+++ b/converters/dbt/tests/__snapshots__/test_osi_to_msi.ambr
@@ -1,4 +1,20 @@
 # serializer version: 1
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 # name: TestOSIToMSIRoundTrip.test_osi_to_msi_to_osi_preserves_structure
   '''
   version: 0.2.0.dev0


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

## Summary

Snapshot files were previously generated by end-users during setup via `uv run pytest --snapshot-update`. This allowed local modifications to silently alter snapshots and could potentially introducing breaking changes. Also, we would need these files during CI later one as well (as we don't want to generate these files on the fly due to the potential breaking changes).

One small catch with those ambr files is the syrupy parser needed first line of the file to be serializer version. Thus, I am adding apache license starting from second line.

Here is the testing result:
```
➜  dbt git:(dbt_snapshots) uv run pytest
warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.11.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/yong/Desktop/GitHome/ossie/converters/dbt
configfile: pyproject.toml
testpaths: tests
plugins: syrupy-5.5.3
collected 94 items

tests/test_msi_to_osi.py ..................................................................                                                                        [ 70%]
tests/test_osi_to_msi.py ............................                                                                                                              [100%]

------------------------------------------------------------------------ snapshot report summary -------------------------------------------------------------------------
5 snapshots passed.
=========================================================================== 94 passed in 0.35s ===========================================================================
```

## Related Issues

<!-- Link any related GitHub issues: Closes #123, Fixes #456 -->

## Checklist

### Specification
- [ ] Spec changes are included in `core-spec/` and follow the existing structure
- [ ] Spec changes have been discussed on the mailing list or in a linked issue
- [ ] Breaking changes to the spec are clearly called out in the summary

### Ontology
- [ ] Ontology changes in `ontology/` are consistent with spec changes
- [ ] New or modified terms are defined and documented

### Converters
- [ ] Converter logic in `converters/` is updated to reflect spec or ontology changes
- [ ] New converters include tests under the converter's test directory

### Validation
- [ ] Validation rules in `validation/` are updated if the spec changed
- [ ] New validation cases are covered by tests

### Documentation
- [ ] `docs/` is updated to reflect any user-facing changes
- [ ] New features or behaviors are documented with examples where appropriate
- [ ] `CONTRIBUTING.md` is updated if the contribution process changed

### Examples
- [ ] `examples/` are added or updated for any new spec constructs or converter support

### Tests
- [x] All existing tests pass (`pytest` / CI green)
- [ ] New functionality is covered by tests

### Compliance
- [x] ASF license headers are present on all new source files
- [x] No third-party dependencies are added without PMC/IPMC approval
