### PR TITLE
Fix orionbelt test

### DIFF
--- a/converters/orionbelt/tests/test_osi_metric_no_silent_loss.py
+++ b/converters/orionbelt/tests/test_osi_metric_no_silent_loss.py
@@ -332,7 +332,7 @@ class TestStaleStashNameCollision:
         }
         osi_again = conv.OBMLtoOSI(obml, "sales").convert()
         result = conv.validate_osi(osi_again)
-        assert result.valid, result.errors
+        assert result.valid, result.summary_lines()
 
 
 class TestIdempotency:


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

## Summary

The current assertion at for `test_output_passes_osi_validation_after_collision()` in test_osi_metric_no_silent_loss.py is looking for `result.errors` which is not an valid attribute in [ValidationResult](https://github.com/apache/ossie/blob/main/converters/orionbelt/src/ossie_orionbelt/validation.py#L68). So if we actually have invalid input that trigger failures would then failed this test by throwing `AttributeErrro`. This PR switched to use `result.summary_lines()` instead.

Here is the test result:
```
➜  orionbelt git:(fix_orionbelt_test) uv run pytest
========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.13.0, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/yong/Desktop/GitHome/ossie/converters/orionbelt
configfile: pyproject.toml
testpaths: tests
collected 154 items

tests/test_osi_converter_cumulative.py .............                                                                                                               [  8%]
tests/test_osi_converter_filters.py ....                                                                                                                           [ 11%]
tests/test_osi_converter_measure_overrides.py .................                                                                                                    [ 22%]
tests/test_osi_converter_ontology.py .......                                                                                                                       [ 26%]
tests/test_osi_converter_pop.py ................                                                                                                                   [ 37%]
tests/test_osi_converter_properties.py ..............................                                                                                              [ 56%]
tests/test_osi_converter_roundtrip_robustness.py .........                                                                                                         [ 62%]
tests/test_osi_converter_trend_v26.py ..........                                                                                                                   [ 68%]
tests/test_osi_converter_vendors.py .......                                                                                                                        [ 73%]
tests/test_osi_metric_no_silent_loss.py ....................                                                                                                       [ 86%]
tests/test_osi_tpcds_baseline.py ...                                                                                                                               [ 88%]
tests/test_osi_v02_compat.py ..................                                                                                                                    [100%]

========================================================================== 154 passed in 0.20s ===========================================================================
```

## Related Issues

<!-- Link any related GitHub issues: Closes #123, Fixes #456 -->

## Checklist

### Specification
- [ ] Spec changes are included in `core-spec/` and follow the existing structure
- [ ] Spec changes have been discussed on the mailing list or in a linked issue
- [ ] Breaking changes to the spec are clearly called out in the summary

### Ontology
- [ ] Ontology changes in `ontology/` are consistent with spec changes
- [ ] New or modified terms are defined and documented

### Converters
- [ ] Converter logic in `converters/` is updated to reflect spec or ontology changes
- [ ] New converters include tests under the converter's test directory

### Validation
- [ ] Validation rules in `validation/` are updated if the spec changed
- [ ] New validation cases are covered by tests

### Documentation
- [ ] `docs/` is updated to reflect any user-facing changes
- [ ] New features or behaviors are documented with examples where appropriate
- [ ] `CONTRIBUTING.md` is updated if the contribution process changed

### Examples
- [ ] `examples/` are added or updated for any new spec constructs or converter support

### Tests
- [x] All existing tests pass (`pytest` / CI green)
- [x] New functionality is covered by tests

### Compliance
- [x] ASF license headers are present on all new source files
- [x] No third-party dependencies are added without PMC/IPMC approval
