### PR TITLE
Add support for quoted dot-separated identifier in snowflake

### DIFF
--- a/converters/snowflake/src/osi_to_snowflake_yaml_converter.py
+++ b/converters/snowflake/src/osi_to_snowflake_yaml_converter.py
@@ -357,6 +357,22 @@ def _normalize_identifier(identifier):
         return stripped
     return stripped.upper()
 
+def _split_identifiers(source_str):
+    """Split a dot-separated identifier string while respecting double quotes."""
+    parts = []
+    current = []
+    in_quotes = False
+    for char in source_str:
+        if char == '"':
+            in_quotes = not in_quotes
+            current.append(char)
+        elif char == "." and not in_quotes:
+            parts.append("".join(current).strip())
+            current = []
+        else:
+            current.append(char)
+    parts.append("".join(current).strip())
+    return parts
 
 def _parse_source(source):
     """Parses an Ossie dataset source string into a Snowflake base_table dict.
@@ -378,11 +394,7 @@ def _parse_source(source):
                           "WITH ", "WITH\n", "WITH\t")):
         return {"definition": source_stripped}
 
-    # Strict 3-part rule: source must be db.schema.table. This may be relaxed
-    # in the future to allow 1- or 2-part names.
-    # TODO: Quoted identifiers (e.g., "my.db"."my schema"."my table") are not
-    # handled. Basic dot-splitting only.
-    parts = source_stripped.split(".")
+    parts = _split_identifiers(source_stripped)
     if len(parts) == 3:
         # Only uppercase unquoted identifiers; preserve quoted ones as-is.
         return {

--- a/converters/snowflake/tests/test_osi_to_snowflake_yaml_converter.py
+++ b/converters/snowflake/tests/test_osi_to_snowflake_yaml_converter.py
@@ -114,6 +114,14 @@ class TestParseSource:
             "table": '"myTable"',
         }
 
+    def test_quoted_identifiers_with_dots_preserved(self):
+        result = _parse_source('"my.db"."my schema"."my table"')
+        assert result == {
+            "database": '"my.db"',
+            "schema": '"my schema"',
+            "table": '"my table"',
+        }
+
     def test_subquery_select(self):
         result = _parse_source("SELECT * FROM foo")
         assert result == {"definition": "SELECT * FROM foo"}


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

## Summary

Resolve TODO in snowflake where quoted dot-separated identifier parsing was not supported.

Here is the testing result with this function and test case:
```
➜  snowflake git:(snowflake_quoted_identifier_support) source .venv/bin/activate
(apache-ossie-snowflake) ➜  snowflake git:(snowflake_quoted_identifier_support) git switch -c "snowflake_quoted_identifier_support"
(apache-ossie-snowflake) ➜  snowflake git:(snowflake_quoted_identifier_support) python3 -m pytest tests/
========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.11.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/yong/Desktop/GitHome/ossie/converters/snowflake
collected 77 items

tests/test_osi_to_snowflake_yaml_converter.py .............................................................................                                        [100%]

=========================================================================== 77 passed in 0.09s ===========================================================================
```

## Related Issues

<!-- Link any related GitHub issues: Closes #123, Fixes #456 -->

## Checklist

### Specification
- [ ] Spec changes are included in `core-spec/` and follow the existing structure
- [ ] Spec changes have been discussed on the mailing list or in a linked issue
- [ ] Breaking changes to the spec are clearly called out in the summary

### Ontology
- [ ] Ontology changes in `ontology/` are consistent with spec changes
- [ ] New or modified terms are defined and documented

### Converters
- [] Converter logic in `converters/` is updated to reflect spec or ontology changes
- [ ] New converters include tests under the converter's test directory

### Validation
- [ ] Validation rules in `validation/` are updated if the spec changed
- [ ] New validation cases are covered by tests

### Documentation
- [ ] `docs/` is updated to reflect any user-facing changes
- [ ] New features or behaviors are documented with examples where appropriate
- [ ] `CONTRIBUTING.md` is updated if the contribution process changed

### Examples
- [ ] `examples/` are added or updated for any new spec constructs or converter support

### Tests
- [x] All existing tests pass (`pytest` / CI green)
- [x] New functionality is covered by tests

### Compliance
- [x] ASF license headers are present on all new source files
- [x] No third-party dependencies are added without PMC/IPMC approval
