### PR TITLE
Addings Slack links and updating slack channel names for accuracy

### DIFF
--- a/docs/working_groups.md
+++ b/docs/working_groups.md
@@ -26,40 +26,40 @@ Join the community on Slack: [join.slack.com/t/opensemanticx](https://join.slack
 | | |
 |---|---|
 | **Lead** | Will Pugh |
-| **Slack channel** | `#metric-language-working-group` |
-| **Google Calendar** | _link TBD_ |
+| **Slack channel** | [`#ossie-metric-language-wg`](https://apache-ossie.slack.com/archives/C0ADR49SBEK) |
+| **Google Calendar** | [Apache Ossie (incubating) Calendar](https://calendar.google.com/calendar/embed?src=a34f013e8d8f9cda419c66af89ab47488644d735fdfe3b0cb2ced90a880a2a95%40group.calendar.google.com&ctz=America%2FChicago) |
 
 ## 2. Composability
 
 | | |
 |---|---|
 | **Lead** | Dianne Wood (AtScale) |
-| **Slack channel** | `#wg-composability` |
-| **Google Calendar** | _link TBD_ |
+| **Slack channel** | [`#ossie-composability-wg`](https://apache-ossie.slack.com/archives/C0BJYHLBKC1) |
+| **Google Calendar** | [Apache Ossie (incubating) Calendar](https://calendar.google.com/calendar/embed?src=a34f013e8d8f9cda419c66af89ab47488644d735fdfe3b0cb2ced90a880a2a95%40group.calendar.google.com&ctz=America%2FChicago) |
 
 ## 3. Catalog
 
 | | |
 |---|---|
 | **Lead** | Shubham Bhargav (Atlan) |
-| **Slack channel** | `#wg-catalog` |
-| **Google Calendar** | _link TBD_ |
+| **Slack channel** | [`#ossie-catalog-wg`](https://apache-ossie.slack.com/archives/C0B8N5VQG1Y) |
+| **Google Calendar** | [Apache Ossie (incubating) Calendar](https://calendar.google.com/calendar/embed?src=a34f013e8d8f9cda419c66af89ab47488644d735fdfe3b0cb2ced90a880a2a95%40group.calendar.google.com&ctz=America%2FChicago) |
 
 ## 4. Ontology
 
 | | |
 |---|---|
 | **Lead** | Kurt (Relational AI) |
-| **Slack channel** | `#osi-ontology` |
-| **Google Calendar** | _link TBD_ |
+| **Slack channel** | [`#ossie-ontology-wg`](https://apache-ossie.slack.com/archives/C0ACQJVFVRN) |
+| **Google Calendar** | [Apache Ossie (incubating) Calendar](https://calendar.google.com/calendar/embed?src=a34f013e8d8f9cda419c66af89ab47488644d735fdfe3b0cb2ced90a880a2a95%40group.calendar.google.com&ctz=America%2FChicago) |
 
 ## 5. Sync API
 
 | | |
 |---|---|
 | **Lead** | Francois Lopitaux (ThoughtSpot) |
-| **Slack channel** | `#wg-sync-api` |
-| **Google Calendar** | _link TBD_ |
+| **Slack channel** | [`#ossie-sync-api-wg`](https://apache-ossie.slack.com/archives/C0BKR0UBG8G) |
+| **Google Calendar** | [Apache Ossie (incubating) Calendar](https://calendar.google.com/calendar/embed?src=a34f013e8d8f9cda419c66af89ab47488644d735fdfe3b0cb2ced90a880a2a95%40group.calendar.google.com&ctz=America%2FChicago) |
 
 ## 6. Financial Services Common Semantics
 

--- a/docs/working_groups.md
+++ b/docs/working_groups.md
@@ -29,15 +29,7 @@ Join the community on Slack: [join.slack.com/t/opensemanticx](https://join.slack
 | **Slack channel** | [`#ossie-metric-language-wg`](https://apache-ossie.slack.com/archives/C0ADR49SBEK) |
 | **Google Calendar** | [Apache Ossie (incubating) Calendar](https://calendar.google.com/calendar/embed?src=a34f013e8d8f9cda419c66af89ab47488644d735fdfe3b0cb2ced90a880a2a95%40group.calendar.google.com&ctz=America%2FChicago) |
 
-## 2. Composability
-
-| | |
-|---|---|
-| **Lead** | Dianne Wood (AtScale) |
-| **Slack channel** | [`#ossie-composability-wg`](https://apache-ossie.slack.com/archives/C0BJYHLBKC1) |
-| **Google Calendar** | [Apache Ossie (incubating) Calendar](https://calendar.google.com/calendar/embed?src=a34f013e8d8f9cda419c66af89ab47488644d735fdfe3b0cb2ced90a880a2a95%40group.calendar.google.com&ctz=America%2FChicago) |
-
-## 3. Catalog
+## 2. Catalog
 
 | | |
 |---|---|
@@ -45,7 +37,7 @@ Join the community on Slack: [join.slack.com/t/opensemanticx](https://join.slack
 | **Slack channel** | [`#ossie-catalog-wg`](https://apache-ossie.slack.com/archives/C0B8N5VQG1Y) |
 | **Google Calendar** | [Apache Ossie (incubating) Calendar](https://calendar.google.com/calendar/embed?src=a34f013e8d8f9cda419c66af89ab47488644d735fdfe3b0cb2ced90a880a2a95%40group.calendar.google.com&ctz=America%2FChicago) |
 
-## 4. Ontology
+## 3. Ontology
 
 | | |
 |---|---|
@@ -53,15 +45,7 @@ Join the community on Slack: [join.slack.com/t/opensemanticx](https://join.slack
 | **Slack channel** | [`#ossie-ontology-wg`](https://apache-ossie.slack.com/archives/C0ACQJVFVRN) |
 | **Google Calendar** | [Apache Ossie (incubating) Calendar](https://calendar.google.com/calendar/embed?src=a34f013e8d8f9cda419c66af89ab47488644d735fdfe3b0cb2ced90a880a2a95%40group.calendar.google.com&ctz=America%2FChicago) |
 
-## 5. Sync API
-
-| | |
-|---|---|
-| **Lead** | Francois Lopitaux (ThoughtSpot) |
-| **Slack channel** | [`#ossie-sync-api-wg`](https://apache-ossie.slack.com/archives/C0BKR0UBG8G) |
-| **Google Calendar** | [Apache Ossie (incubating) Calendar](https://calendar.google.com/calendar/embed?src=a34f013e8d8f9cda419c66af89ab47488644d735fdfe3b0cb2ced90a880a2a95%40group.calendar.google.com&ctz=America%2FChicago) |
-
-## 6. Financial Services Common Semantics
+## 4. Financial Services Common Semantics
 
 | | |
 |---|---|


### PR DESCRIPTION


<!-- Describe what this PR does and why. -->

## Related Issues

- Link all working group Slack channels with updated names
  (`#ossie-metric-language-wg, #ossie-composability-wg, #ossie-catalog-wg, #ossie-ontology-wg, #ossie-sync-api-wg`)
- Replace "link TBD" calendar entries with the shared Apache Ossie (incubating) Calendar

Note: Some channel names were updated to follow the consistent ossie-*-wg naming convention. The old names (`#metric-language-working-group, #wg-composability, #wg-catalog, #osi-ontology, #wg-sync-api`) no longer exist.

## Checklist

### Documentation
- [X] `docs/` is updated to reflect any user-facing changes
- [X] New features or behaviors are documented with examples where appropriate
- [X] `CONTRIBUTING.md` is updated if the contribution process changed
