### PR TITLE
Use Ossie branding instead of former name Open Semantic Interchange

### DIFF
--- a/converters/dbt/pyproject.toml
+++ b/converters/dbt/pyproject.toml
@@ -36,7 +36,6 @@ license = "Apache-2.0"
 keywords = [
     "Apache Ossie",
     "Ossie",
-    "Open Semantic Interchange",
     "dbt"
 ]
 dependencies = [

--- a/converters/honeydew/pyproject.toml
+++ b/converters/honeydew/pyproject.toml
@@ -36,7 +36,6 @@ license = "Apache-2.0"
 keywords = [
     "Apache Ossie",
     "Ossie",
-    "Open Semantic Interchange",
     "Honeydew"
 ]
 dependencies = [

--- a/converters/omni/pyproject.toml
+++ b/converters/omni/pyproject.toml
@@ -36,7 +36,6 @@ license = "Apache-2.0"
 keywords = [
     "Apache Ossie",
     "Ossie",
-    "Open Semantic Interchange",
     "Omni"
 ]
 dependencies = [

--- a/converters/orionbelt/README.md
+++ b/converters/orionbelt/README.md
@@ -20,7 +20,7 @@
 # apache-ossie-orionbelt
 
 Bidirectional converter between **OBML** (OrionBelt Markup Language) semantic
-models and **OSI** ([Open Semantic Interchange](https://open-semantic-interchange.org/)),
+models and **Ossie** ([Apache Ossie](https://ossie.apache.org/)),
 the open standard for portable semantic models (metrics, dimensions,
 relationships).
 

--- a/converters/orionbelt/osi_obml_mapping_analysis.md
+++ b/converters/orionbelt/osi_obml_mapping_analysis.md
@@ -19,7 +19,7 @@
 
 # OSI ↔ OBML Mapping Analysis
 
-> Bidirectional conversion between [Open Semantic Interchange (OSI)](https://github.com/open-semantic-interchange/OSI) v0.2.0.dev0 and [OrionBelt ML (OBML)](https://github.com/ralfbecher/orionbelt-semantic-layer) v1.0 semantic model formats. OSI v0.1.x inputs are still accepted on read via a legacy normalization shim; output targets v0.2.0.dev0.
+> Bidirectional conversion between [Ossie](https://ossie.apache.org/) v0.2.0.dev0 and [OrionBelt ML (OBML)](https://github.com/ralfbecher/orionbelt-semantic-layer) v1.0 semantic model formats. OSI v0.1.x inputs are still accepted on read via a legacy normalization shim; output targets v0.2.0.dev0.
 
 ## 1. Structural Comparison
 

--- a/converters/orionbelt/pyproject.toml
+++ b/converters/orionbelt/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
 [project]
 name = "apache-ossie-orionbelt"
 version = "0.2.0.dev0"
-description = "Bidirectional OBML <-> OSI (Open Semantic Interchange) converter for OrionBelt semantic models"
+description = "Bidirectional OBML <-> Ossie converter for OrionBelt semantic models"
 authors = [{ name = "Apache Software Foundation", email = "dev@ossie.apache.org" }]
 requires-python = ">=3.12"
 readme = "README.md"
@@ -39,7 +39,6 @@ license = "Apache-2.0"
 keywords = [
     "Apache Ossie",
     "Ossie",
-    "Open Semantic Interchange",
     "orionbelt"
 ]
 dependencies = [

--- a/converters/orionbelt/src/ossie_orionbelt/converter.py
+++ b/converters/orionbelt/src/ossie_orionbelt/converter.py
@@ -18,7 +18,7 @@
 """
 OSI ↔ OBML Bidirectional Converter
 ===================================
-Converts between Open Semantic Interchange (OSI v0.2.0.dev0) YAML models
+Converts between Ossie (v0.2.0.dev0) YAML models
 and OrionBelt Markup Language (OBML v1.0) YAML models.
 
 OSI v0.1.1 inputs are still accepted on read — the legacy shim

--- a/converters/snowflake/pyproject.toml
+++ b/converters/snowflake/pyproject.toml
@@ -35,7 +35,6 @@ license = "Apache-2.0"
 keywords = [
     "Apache Ossie",
     "Ossie",
-    "Open Semantic Interchange",
     "Snowflake"
 ]
 dependencies = [

--- a/converters/snowflake/src/ossie_snowflake/converter.py
+++ b/converters/snowflake/src/ossie_snowflake/converter.py
@@ -16,7 +16,7 @@
 # under the License.
 
 """
-Converts an Ossie (Open Semantic Interchange) YAML semantic model to a Snowflake
+Converts an Ossie YAML semantic model to a Snowflake
 Cortex Analyst semantic model YAML. Pure offline conversion — no Snowflake
 connection required.
 

--- a/converters/wisdom/pyproject.toml
+++ b/converters/wisdom/pyproject.toml
@@ -35,7 +35,6 @@ license = "Apache-2.0"
 keywords = [
     "Apache Ossie",
     "Ossie",
-    "Open Semantic Interchange",
     "WisdomAI"
 ]
 dependencies = [

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -30,7 +30,6 @@ license = "Apache-2.0"
 keywords = [
     "Apache Ossie",
     "Ossie",
-    "Open Semantic Interchange",
 ]
 dependencies = [
     "pydantic>=2.0",


### PR DESCRIPTION
## Summary

The project was renamed to **Apache Ossie**. This PR replaces the remaining stale occurrences of the former name *Open Semantic Interchange* with **Ossie** across package metadata, docstrings, and converter docs.

## Changes

- **`pyproject.toml` keywords** (python, dbt, honeydew, omni, orionbelt, snowflake, wisdom): dropped the redundant `"Open Semantic Interchange"` keyword — `"Apache Ossie"` and `"Ossie"` were already present in every list.
- **`converters/orionbelt/pyproject.toml`**: description now reads `Bidirectional OBML <-> Ossie converter ...`.
- **`converters/orionbelt/README.md`** and **`osi_obml_mapping_analysis.md`**: prose/links updated to Ossie (https://ossie.apache.org/).
- **`converters/orionbelt` and `converters/snowflake` converter docstrings**: reference Ossie instead of the old name.
- Added the missing final newline to several `pyproject.toml` files to satisfy `.editorconfig` (`insert_final_newline = true`).

## Intentionally kept

The historical *"formerly known as **Open Semantic Interchange (OSI)**"* lines in `README.md`, `CONTRIBUTING.md`, and `docs/index.md` are correct and left in place.

The standalone `OSI` acronym (module names, `OSI v0.2.0.dev0` format-version labels, headings) is out of scope for this branding cleanup and untouched.