### PR TITLE
adding shared ruff config, pre-commit hooks, and makefile for python linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.12
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,47 @@ is being made):
 4. **Find something to work on**: Browse the [issues](https://github.com/apache/ossie/issues), or raise a topic on the dev list.
 5. **Submit a Pull Request**: Fork the repository, make your changes, and submit a pull request. All contributions go through the review process described below.
 
+## Development Setup
+
+### Python
+
+The project uses [ruff](https://docs.astral.sh/ruff/) for linting and formatting
+across all Python packages. A shared configuration lives in the top-level `ruff.toml`.
+
+```bash
+# Install ruff (if not already available)
+pip install ruff
+
+# Check for lint issues
+make lint
+
+# Auto-format code
+make format
+
+# Check formatting without modifying files
+make format-check
+```
+
+**Optional: pre-commit hooks** — If you'd like automatic formatting on every commit:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+This runs ruff lint (with auto-fix) and ruff format before each commit, so issues
+are caught locally before pushing.
+
+### Go
+
+The `cli/` directory has its own `Makefile` with `make lint` (runs `go vet`) and
+`make format` (runs `gofmt`).
+
+### Java
+
+The Maven converters (`converters/salesforce/`, `converters/polaris/`) are built with
+`mvn verify`. Apache RAT checks license headers during the verify phase.
+
 ## Contributor License Agreement (ICLA)
 
 All contributions to Apache Ossie are made under the [Apache License 2.0](LICENSE).

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+.PHONY: lint format
+
+lint:
+	@echo "Running ruff check on all Python packages..."
+	ruff check python/ converters/ validation/
+
+format:
+	@echo "Running ruff format on all Python packages..."
+	ruff format python/ converters/ validation/
+
+format-check:
+	@echo "Checking formatting (no changes)..."
+	ruff format --check python/ converters/ validation/

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+line-length = 120
+target-version = "py311"
+
+[lint]
+select = ["E", "F", "I", "UP", "W"]
+ignore = ["E501"]
+
+[format]
+quote-style = "double"


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Adds shared Python linting and formatting infrastructure for the project. Currently, 3 of 7 Python packages have ruff configured with inconsistent settings (different line lengths, different rule sets), while 4 packages have no linting at all. This PR establishes a single source of truth for code style, opt-in local tooling, and contributor guidance.

File added

1. ruff.toml — shared config (line-length 120, target py311, rules: E/F/I/UP/W)
2. .pre-commit-config.yaml — opt-in ruff hooks for local auto-formatting
3. Makefile — make lint / make format / make format-check targets
4. CONTRIBUTING.md — new "Development Setup" section with instructions for Python, Go, and Java


- Does not modify or reformat any existing Python source code
- Does not add CI enforcement (that will be a follow-up PR)
- Does not touch Java or Go tooling
- Discussed on dev@ossie.apache.org [link](https://lists.apache.org/thread/4pzt7ck1p97hw0clfj3yyh1yxh3tg9zh)
-----
Rationale:

1. line-length = 120: 2 of 3 existing configs already use this
2. target-version = py311: our lowest common Python version
3. Rules: E (pycodestyle errors), F (pyflakes - catches real bugs like unused imports, undefined names), I (isort - consistent import order), UP (pyupgrade - modernize syntax), W (warnings)
4. E501 ignored because ruff format handles line wrapping
5. No opinion-heavy style rules - intentionally conservative

## Checklist

### Documentation
- [X] `CONTRIBUTING.md` is updated if the contribution process changed

### Compliance
- [X] ASF license headers are present on all new source files

