### PR TITLE
docs: add Chinese and Japanese README translations

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,43 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+# Apache Ossie（インキュベーション中）
+
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja.md)
+
+Apache Ossie は、データ分析、AI、BI のエコシステムに存在する多様なツールやプラットフォーム間で、セマンティックモデルの交換と利用を標準化・効率化するための、協力型オープンソースプロジェクトです。私たちが共有するビジョンは、共通かつベンダーに依存しないセマンティックモデル仕様を確立し、すべての参加者に比類のない相互運用性、効率性、コラボレーションをもたらすことです。このベンダー非依存の標準は、単一で一貫した信頼できる情報源を提供します。これにより、データの定義と価値は、AI エージェント、BI プラットフォーム、エコシステム内のその他すべてのツールの間で交換されても一貫性を保ち、異なるツール間の不整合を解消します。
+
+Apache Ossie は、以前は **Open Semantic Interchange (OSI)** と呼ばれていました。
+
+Apache Ossie は、あらゆるツールが読み書きできる、JSON および YAML ベースの単一仕様を提供します。これは、今日のデータスタックで一般的なセマンティックの断片化に対処するものです。たとえば、同じ KPI がツールごとに異なって定義されること、チームが定義の手作業による調整に多大な労力を費やすこと、一貫性のないビジネスロジックに基づいて AI エージェントが信頼できない出力を生成することなどです。
+
+## このリポジトリの内容
+
+- [`core-spec/`](core-spec/) — Ossie コア仕様（`spec.md`）、機械可読スキーマ（`spec.yaml`、`osi-schema.json`）、および関連ドキュメント。
+- [`converters/`](converters/) — Ossie と他のセマンティック形式（dbt、GoodData、Polaris、Salesforce など）の間で変換するリファレンスコンバーター。
+- [`examples/`](examples/) — 完全な TPC-DS モデルを含むセマンティックモデルの例。
+- [`validation/`](validation/) — Ossie スキーマに照らしてセマンティックモデルを検証するためのツール。
+- [`docs/`](docs/) — プロジェクトのドキュメントと概要。
+
+## プロジェクトへの参加
+
+- **コントリビューション：** 仕様変更の提案、コードの提供、コミュニティへの参加方法については、[CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。
+- **ロードマップ：** 現在のワーキンググループ、今後の取り組み、コミュニティでの議論を踏まえた改善計画については、[ROADMAP.md](ROADMAP.md) を参照してください。
+- **ディスカッション：** [GitHub Discussions](https://github.com/apache/ossie/discussions) と [Issues](https://github.com/apache/ossie/issues) で会話に参加してください。
+- **Slack コミュニティへの参加：** [Slack](https://join.slack.com/t/apache-ossie/shared_invite/zt-42zw4rflt-Gpve8_NFJq7AsdAQTY~SCg) でコントリビューターと直接交流できます。

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 # Apache Ossie (incubating)
 
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja.md)
+
 Apache Ossie is a collaborative, open-source effort dedicated to standardizing and streamlining semantic model exchange and utilization across the diverse array of tools and platforms within the data analytics, AI, and BI ecosystem. Our shared vision is to establish a common, vendor-agnostic semantic model specification, promoting unparalleled interoperability, efficiency, and collaboration among all participants. By providing a single, consistent source of truth, this vendor-agnostic standard ensures that your data's definitions and value remain consistent as they are interchanged between AI agents, BI platforms, and all other tools in your ecosystem, eliminating inconsistencies across your different tools.
 
 Apache Ossie was formerly known as **Open Semantic Interchange (OSI)**.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,43 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+# Apache Ossie（孵化中）
+
+[English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja.md)
+
+Apache Ossie 是一项协作式开源计划，致力于在数据分析、AI 和 BI 生态系统中种类繁多的工具与平台之间，推动语义模型交换和使用方式的标准化与简化。我们的共同愿景是建立一套通用、厂商无关的语义模型规范，为所有参与者带来前所未有的互操作性、效率与协作能力。这项厂商无关的标准提供单一且一致的事实来源，确保数据的定义和价值在 AI 智能体、BI 平台及生态系统中的其他工具之间交换时保持一致，从而消除不同工具之间的不一致。
+
+Apache Ossie 的原名为 **Open Semantic Interchange (OSI)**。
+
+Apache Ossie 提供一套基于 JSON 和 YAML 的统一规范，任何工具都可以读写。它旨在解决当今数据技术栈中普遍存在的语义碎片化问题，例如：同一个 KPI 在不同工具中定义不一致、团队耗费大量精力手动协调定义，以及 AI 智能体基于不一致的业务逻辑生成不可靠的输出。
+
+## 本仓库包含什么
+
+- [`core-spec/`](core-spec/) — Ossie 核心规范（`spec.md`）、机器可读的 Schema（`spec.yaml`、`osi-schema.json`）及相关文档。
+- [`converters/`](converters/) — 在 Ossie 与其他语义格式（例如 dbt、GoodData、Polaris、Salesforce）之间进行转换的参考转换器。
+- [`examples/`](examples/) — 语义模型示例，其中包括完整的 TPC-DS 模型。
+- [`validation/`](validation/) — 用于依据 Ossie Schema 验证语义模型的工具。
+- [`docs/`](docs/) — 项目文档和概览。
+
+## 参与项目
+
+- **贡献：** 有关如何提出规范变更、贡献代码以及参与社区的信息，请参阅 [CONTRIBUTING.md](CONTRIBUTING.md)。
+- **路线图：** 有关当前工作组、未来工作以及由社区讨论推动的计划改进，请参阅 [ROADMAP.md](ROADMAP.md)。
+- **讨论：** 在 [GitHub Discussions](https://github.com/apache/ossie/discussions) 和 [Issues](https://github.com/apache/ossie/issues) 中参与交流。
+- **加入 Slack 社区：** 在 [Slack](https://join.slack.com/t/apache-ossie/shared_invite/zt-42zw4rflt-Gpve8_NFJq7AsdAQTY~SCg) 上直接与贡献者交流。


### PR DESCRIPTION
## Summary

Adds complete Simplified Chinese and Japanese translations of the root README and links all three language versions. Both translations preserve the English README structure, technical terms, links, and ASF license header.

## Related Issues

N/A — documentation-only translation.

## Checklist

### Documentation

- [x] Added complete `README.zh-CN.md` and `README.ja.md` translations.
- [x] Verified both files match the source structure (43 lines, 3 headings, 9 list items, and 10 links), and all relative links resolve.

### Tests

- [x] Documentation-only change; no code tests are applicable.
- [x] `git diff --check` passes.

### Compliance

- [x] ASF license headers are present on both new files.
- [x] No third-party dependencies are added.