### PR TITLE
fix(doc): fix broken image link

### DIFF
--- a/core-spec/expression_language.md
+++ b/core-spec/expression_language.md
@@ -29,7 +29,7 @@
 
 ## Overview
 
-![Ossie Layers](img/Ossie_layers.png)
+![Ossie Layers](img/ossie_layers.png)
 
 There are two layers in Ossie that need an expression language:
 


### PR DESCRIPTION
## Summary

Fix broken image link

## Related Issues

minor fix

Before:
<img width="1436" height="562" alt="image" src="https://github.com/user-attachments/assets/189ee961-6034-447f-aac3-77d383ea1213" />

After:
<img width="1407" height="571" alt="image" src="https://github.com/user-attachments/assets/bfdb9da0-8a53-45b2-ab68-cdb1a4b651ab" />


