### PR TITLE
Fix Omni pytest

### DIFF
--- a/converters/omni/src/osi_omni/osi_to_omni.py
+++ b/converters/omni/src/osi_omni/osi_to_omni.py
@@ -373,7 +373,15 @@ def _convert_field(field, dname, expr, fscope):
     if instructions:
         dim["ai_context"] = instructions
 
-    if (field.get("dimension") or {}).get("is_time"):
+    dimension = field.get("dimension")
+    is_time = False
+    if dimension is not None:
+        is_time_explicit = dimension.get("is_time")
+        if is_time_explicit is not None:
+            is_time = bool(is_time_explicit)
+        else:
+            is_time = field.get("datatype") in ("Date", "Time", "DateTime", "DateTimez")
+    if is_time:
         # The stashed list wins even when empty (`timeframes: []` is a real
         # Omni value); the default list is only for hand-authored OSI.
         dim["timeframes"] = (stash["timeframes"] if "timeframes" in stash

--- a/converters/omni/tests/_util.py
+++ b/converters/omni/tests/_util.py
@@ -107,8 +107,19 @@ def strip_normalized(osi):
             fields = ds.get("fields", []) or []
             for field in fields:
                 field.pop("custom_extensions", None)
-                if field.get("dimension") == {"is_time": False}:
-                    field.pop("dimension")
+                dimension = field.get("dimension")
+                is_time = False
+                if dimension is not None:
+                    is_time_explicit = dimension.get("is_time")
+                    if is_time_explicit is not None:
+                        is_time = bool(is_time_explicit)
+                    else:
+                        is_time = field.get("datatype") in ("Date", "Time", "DateTime", "DateTimez")
+                field.pop("datatype", None)
+                if is_time:
+                    field["dimension"] = {"is_time": True}
+                else:
+                    field.pop("dimension", None)
             # Drop backfilled key fields: a bare-column field named after a
             # primary_key column, carrying nothing but its expression.
             pk = set(ds.get("primary_key") or [])
@@ -126,6 +137,7 @@ def strip_normalized(osi):
             rel.pop("custom_extensions", None)
         for metric in model.get("metrics", []) or []:
             metric.pop("custom_extensions", None)
+            metric.pop("datatype", None)
         # Metric order is not semantic; the import regroups metrics by the view
         # their measure lives on.
         if model.get("metrics"):


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

## Summary

This is sample fix for https://github.com/apache/ossie/issues/260. There are two issues introduced by https://github.com/apache/ossie/pull/113:
1. the new `datatype` field caused `test_tpcds_export_matches_expected` to fail due to Omni exporter lacks the logic to default `is_time: true` for temporal-typed fields whose explicit dimension role was unset
2. the `test_osi_roundtrip_up_to_documented_normalizations` fails due to non-native `datatype` property is dropped upon export but the test's normalization helper didn't remove it from the compared semantic model.


## Related Issues

<!-- Link any related GitHub issues: Closes #123, Fixes #456 -->

## Checklist

### Specification
- [ ] Spec changes are included in `core-spec/` and follow the existing structure
- [ ] Spec changes have been discussed on the mailing list or in a linked issue
- [ ] Breaking changes to the spec are clearly called out in the summary

### Ontology
- [ ] Ontology changes in `ontology/` are consistent with spec changes
- [ ] New or modified terms are defined and documented

### Converters
- [ ] Converter logic in `converters/` is updated to reflect spec or ontology changes
- [ ] New converters include tests under the converter's test directory

### Validation
- [ ] Validation rules in `validation/` are updated if the spec changed
- [ ] New validation cases are covered by tests

### Documentation
- [ ] `docs/` is updated to reflect any user-facing changes
- [ ] New features or behaviors are documented with examples where appropriate
- [ ] `CONTRIBUTING.md` is updated if the contribution process changed

### Examples
- [ ] `examples/` are added or updated for any new spec constructs or converter support

### Tests
- [x] All existing tests pass (`pytest` / CI green)
- [ ] New functionality is covered by tests

### Compliance
- [ ] ASF license headers are present on all new source files
- [ ] No third-party dependencies are added without PMC/IPMC approval
