### PR TITLE
Updating CI Actions path

### DIFF
--- a/.github/workflows/converter-dbt-ci.yml
+++ b/.github/workflows/converter-dbt-ci.yml
@@ -24,12 +24,12 @@ on:
     branches: [ "main" ]
     paths:
       - 'converters/dbt/**'
-      - '.github/**'    
+      - '.github/workflows/converter-dbt-ci.yml'    
   pull_request:
     branches: [ "main" ]
     paths:
       - 'converters/dbt/**'
-      - '.github/**'    
+      - '.github/workflows/converter-dbt-ci.yml'    
 
 jobs:
   build:

--- a/.github/workflows/converter-gooddata-ci.yml
+++ b/.github/workflows/converter-gooddata-ci.yml
@@ -24,12 +24,12 @@ on:
     branches: [ "main" ]
     paths:
       - 'converters/gooddata/**'
-      - '.github/**'    
+      - '.github/workflows/converter-gooddata-ci.yml'    
   pull_request:
     branches: [ "main" ]
     paths:
       - 'converters/gooddata/**'
-      - '.github/**'    
+      - '.github/workflows/converter-gooddata-ci.yml'    
 
 jobs:
   build:

--- a/.github/workflows/converter-honeydew-ci.yml
+++ b/.github/workflows/converter-honeydew-ci.yml
@@ -24,12 +24,12 @@ on:
     branches: [ "main" ]
     paths:
       - 'converters/honeydew/**'
-      - '.github/**'    
+      - '.github/workflows/converter-honeydew-ci.yml'    
   pull_request:
     branches: [ "main" ]
     paths:
       - 'converters/honeydew/**'
-      - '.github/**'    
+      - '.github/workflows/converter-honeydew-ci.yml'    
 
 jobs:
   build:

--- a/.github/workflows/converter-omni-ci.yml
+++ b/.github/workflows/converter-omni-ci.yml
@@ -24,12 +24,12 @@ on:
     branches: [ "main" ]
     paths:
       - 'converters/omni/**'
-      - '.github/**'    
+      - '.github/workflows/converter-omni-ci.yml'    
   pull_request:
     branches: [ "main" ]
     paths:
       - 'converters/omni/**'
-      - '.github/**'    
+      - '.github/workflows/converter-omni-ci.yml'    
 
 jobs:
   build:

--- a/.github/workflows/converter-orionbelt-ci.yml
+++ b/.github/workflows/converter-orionbelt-ci.yml
@@ -24,12 +24,12 @@ on:
     branches: [ "main" ]
     paths:
       - 'converters/orionbelt/**'
-      - '.github/**'    
+      - '.github/workflows/converter-orionbelt-ci.yml'    
   pull_request:
     branches: [ "main" ]
     paths:
       - 'converters/orionbelt/**'
-      - '.github/**'    
+      - '.github/workflows/converter-orionbelt-ci.yml'    
 
 jobs:
   build:

--- a/.github/workflows/converter-polaris-ci.yml
+++ b/.github/workflows/converter-polaris-ci.yml
@@ -24,12 +24,12 @@ on:
     branches: [ "main" ]
     paths:
       - 'converters/polaris/**'
-      - '.github/**'
+      - '.github/workflows/converter-polaris-ci.yml'
   pull_request:
     branches: [ "main" ]
     paths:
       - 'converters/polaris/**'
-      - '.github/**'
+      - '.github/workflows/converter-polaris-ci.yml'
 
 jobs:
   build:

--- a/.github/workflows/converter-salesforce-ci.yml
+++ b/.github/workflows/converter-salesforce-ci.yml
@@ -24,12 +24,12 @@ on:
     branches: [ "main" ]
     paths:
       - 'converters/salesforce/**'
-      - '.github/**'
+      - '.github/workflows/converter-salesforce-ci.yml'
   pull_request:
     branches: [ "main" ]
     paths:
       - 'converters/salesforce/**'
-      - '.github/**'
+      - '.github/workflows/converter-salesforce-ci.yml'
 
 jobs:
   build:

--- a/.github/workflows/converter-snowflake-ci.yml
+++ b/.github/workflows/converter-snowflake-ci.yml
@@ -24,12 +24,12 @@ on:
     branches: [ "main" ]
     paths:
       - 'converters/snowflake/**'
-      - '.github/**'    
+      - '.github/workflows/converter-snowflake-ci.yml'    
   pull_request:
     branches: [ "main" ]
     paths:
       - 'converters/snowflake/**'
-      - '.github/**'    
+      - '.github/workflows/converter-snowflake-ci.yml'    
 
 jobs:
   build:


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

## Summary

While working on PR #259, I noticed that all 8 converter CI workflows use .github/** as a path trigger. This means any PR that touches anything under ```.github/``` triggers every converter's test suite unnecessarily. 

This wastes CI resources and creates confusing failures on unrelated PRs (e.g., #259 showed a failing Omni build that had nothing to do with the docs changes).

This fix narrows each workflow's path filter to only reference its own workflow file, so a converter's CI only runs when its converter code or its own workflow definition changes.

## Related Issues

#259
