### PR TITLE
Bump java version from 11 to 17 for Polaris converter

### DIFF
--- a/.github/workflows/converter-polaris-ci.yml
+++ b/.github/workflows/converter-polaris-ci.yml
@@ -42,10 +42,10 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
 

--- a/converters/polaris/README.md
+++ b/converters/polaris/README.md
@@ -29,7 +29,7 @@ Apache Polaris is an open-source catalog for Apache Iceberg. This converter comm
 mvn clean package
 ```
 
-Requires Java 11+.
+Requires Java 17+.
 
 ## Usage
 

--- a/converters/polaris/pom.xml
+++ b/converters/polaris/pom.xml
@@ -39,9 +39,9 @@
     <description>Converts between Apache Ossie semantic models and Apache Polaris catalog metadata</description>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <snakeyaml.version>2.2</snakeyaml.version>
         <jackson.version>2.18.9</jackson.version>


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

## Summary

Java 11 had been EOL for quite some time. It is still possible to get extended support when using cloud provider version or purchase an extended support version from different vendor, but we should stay away from EOL software.

## Related Issues

<!-- Link any related GitHub issues: Closes #123, Fixes #456 -->

## Checklist

### Specification
- [ ] Spec changes are included in `core-spec/` and follow the existing structure
- [ ] Spec changes have been discussed on the mailing list or in a linked issue
- [ ] Breaking changes to the spec are clearly called out in the summary

### Ontology
- [ ] Ontology changes in `ontology/` are consistent with spec changes
- [ ] New or modified terms are defined and documented

### Converters
- [ ] Converter logic in `converters/` is updated to reflect spec or ontology changes
- [ ] New converters include tests under the converter's test directory

### Validation
- [ ] Validation rules in `validation/` are updated if the spec changed
- [ ] New validation cases are covered by tests

### Documentation
- [ ] `docs/` is updated to reflect any user-facing changes
- [ ] New features or behaviors are documented with examples where appropriate
- [ ] `CONTRIBUTING.md` is updated if the contribution process changed

### Examples
- [ ] `examples/` are added or updated for any new spec constructs or converter support

### Tests
- [ ] All existing tests pass (`pytest` / CI green)
- [ ] New functionality is covered by tests

### Compliance
- [ ] ASF license headers are present on all new source files
- [ ] No third-party dependencies are added without PMC/IPMC approval
