### PR TITLE
feat: handle symlinked plugin directories in Discover

### DIFF
--- a/cli/internal/plugin/discover.go
+++ b/cli/internal/plugin/discover.go
@@ -33,10 +33,19 @@ func Discover(pluginsDir string, stderr io.Writer) ([]*Plugin, error) {
 
 	var plugins []*Plugin
 	for _, entry := range entries {
-		// TODO: handle symlinked plugin directories
-		// (entry.Type()&os.ModeSymlink != 0 requires os.Stat to resolve)
 		if !entry.IsDir() {
-			continue
+			if entry.Type()&os.ModeSymlink == 0 {
+				continue
+			}
+			entryPath := filepath.Join(pluginsDir, entry.Name())
+			resolved, err := os.Stat(entryPath)
+			if err != nil {
+				fmt.Fprintf(stderr, "warning: skipping plugin at %s: %s\n", entryPath, err)
+				continue
+			}
+			if !resolved.IsDir() {
+				continue
+			}
 		}
 		pluginPath := filepath.Join(pluginsDir, entry.Name())
 		p, err := loadPlugin(pluginPath)

--- a/cli/internal/plugin/discover_test.go
+++ b/cli/internal/plugin/discover_test.go
@@ -304,10 +304,10 @@ func TestDiscover_symlinkedPluginDirectory(t *testing.T) {
 
 	// Create pluginsDir with a symlink to the real plugin directory
 	pluginsDir := t.TempDir()
-symlinkPath := filepath.Join(pluginsDir, "dbt-link")
-if err := os.Symlink(pluginDir, symlinkPath); err != nil {
-	t.Skipf("symlinks not supported or not permitted on this platform: %v", err)
-}
+	symlinkPath := filepath.Join(pluginsDir, "dbt-link")
+	if err := os.Symlink(pluginDir, symlinkPath); err != nil {
+		t.Skipf("symlinks not supported or not permitted on this platform: %v", err)
+	}
 
 	var stderr strings.Builder
 	plugins, err := plugin.Discover(pluginsDir, &stderr)

--- a/cli/internal/plugin/discover_test.go
+++ b/cli/internal/plugin/discover_test.go
@@ -304,10 +304,10 @@ func TestDiscover_symlinkedPluginDirectory(t *testing.T) {
 
 	// Create pluginsDir with a symlink to the real plugin directory
 	pluginsDir := t.TempDir()
-	symlinkPath := filepath.Join(pluginsDir, "dbt-link")
-	if err := os.Symlink(pluginDir, symlinkPath); err != nil {
-		t.Fatalf("could not create symlink: %v", err)
-	}
+symlinkPath := filepath.Join(pluginsDir, "dbt-link")
+if err := os.Symlink(pluginDir, symlinkPath); err != nil {
+	t.Skipf("symlinks not supported or not permitted on this platform: %v", err)
+}
 
 	var stderr strings.Builder
 	plugins, err := plugin.Discover(pluginsDir, &stderr)

--- a/cli/internal/plugin/discover_test.go
+++ b/cli/internal/plugin/discover_test.go
@@ -296,3 +296,62 @@ func TestDiscover_setupFieldAbsent(t *testing.T) {
 		t.Errorf("Setup: got %q, want empty string", plugins[0].Setup)
 	}
 }
+
+func TestDiscover_symlinkedPluginDirectory(t *testing.T) {
+	// Create the real plugin directory outside pluginsDir
+	realRoot := t.TempDir()
+	pluginDir := writePlugin(t, realRoot, "dbt", validPluginYAML)
+
+	// Create pluginsDir with a symlink to the real plugin directory
+	pluginsDir := t.TempDir()
+	symlinkPath := filepath.Join(pluginsDir, "dbt-link")
+	if err := os.Symlink(pluginDir, symlinkPath); err != nil {
+		t.Fatalf("could not create symlink: %v", err)
+	}
+
+	var stderr strings.Builder
+	plugins, err := plugin.Discover(pluginsDir, &stderr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(plugins) != 1 {
+		t.Fatalf("expected 1 plugin via symlink, got %d", len(plugins))
+	}
+	p := plugins[0]
+	if p.Path != symlinkPath {
+		t.Errorf("Path: got %q, want %q", p.Path, symlinkPath)
+	}
+	if p.Name != "dbt" {
+		t.Errorf("Name: got %q, want %q", p.Name, "dbt")
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("unexpected warning: %q", stderr.String())
+	}
+}
+
+func TestDiscover_brokenSymlink(t *testing.T) {
+	pluginsDir := t.TempDir()
+
+	// Create a symlink pointing to a non-existent target
+	brokenTarget := filepath.Join(pluginsDir, "nonexistent-dir")
+	symlinkPath := filepath.Join(pluginsDir, "broken-link")
+	if err := os.Symlink(brokenTarget, symlinkPath); err != nil {
+		t.Fatalf("could not create symlink: %v", err)
+	}
+
+	// Create a valid plugin to ensure Discover can still find non-symlink dirs
+	writePlugin(t, pluginsDir, "valid", validPluginYAML)
+
+	var stderr strings.Builder
+	plugins, err := plugin.Discover(pluginsDir, &stderr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(plugins) != 1 {
+		t.Errorf("expected 1 valid plugin, got %d", len(plugins))
+	}
+	warnings := stderr.String()
+	if !strings.Contains(warnings, symlinkPath) {
+		t.Errorf("warning should contain broken symlink path, got: %q", warnings)
+	}
+}


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

## Summary

`Discover` currently skips symlinked plugin directories because
`os.ReadDir` entries for symlinks have `ModeSymlink` rather than
`ModeDir`, causing `entry.IsDir()` to return `false`.

This PR resolves symlinks via `os.Stat` so that plugin directories
placed behind a symlink are correctly discovered. Broken symlinks
produce a warning and are skipped (consistent with the existing
skip-warning behaviour for malformed plugins).

## Related Issues

<!-- Link any related GitHub issues: Closes #123, Fixes #456 -->

## Checklist

### Specification
- [ ] Spec changes are included in `core-spec/` and follow the existing structure
- [ ] Spec changes have been discussed on the mailing list or in a linked issue
- [ ] Breaking changes to the spec are clearly called out in the summary

### Ontology
- [ ] Ontology changes in `ontology/` are consistent with spec changes
- [ ] New or modified terms are defined and documented

### Converters
- [ ] Converter logic in `converters/` is updated to reflect spec or ontology changes
- [ ] New converters include tests under the converter's test directory

### Validation
- [ ] Validation rules in `validation/` are updated if the spec changed
- [ ] New validation cases are covered by tests

### Documentation
- [ ] `docs/` is updated to reflect any user-facing changes
- [ ] New features or behaviors are documented with examples where appropriate
- [ ] `CONTRIBUTING.md` is updated if the contribution process changed

### Examples
- [ ] `examples/` are added or updated for any new spec constructs or converter support

### Tests
- [x] All existing tests pass (`go test ./...` / CI green)
- [x] New functionality is covered by tests

### Compliance
- [ ] ASF license headers are present on all new source files
- [ ] No third-party dependencies are added without PMC/IPMC approval